### PR TITLE
翻訳ファイルの追加および既存のビューファイルへのi18n対応

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to new_user_path, notice: 'ユーザー登録が完了しました'
+      redirect_to new_user_path, notice: t('defaults.message.created', item: User.model_name.human)
     else
-      flash[:alert] = 'ユーザー登録ができませんでした'
+      flash[:alert] = t('defaults.message.not_created', item: User.model_name.human)
       render :new
     end
   end

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,4 +1,4 @@
 - if object.errors.present?
   ul
     - object.errors.full_messages.each do |message|
-        = message
+        li = message

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+    attributes:
+      user:
+        name: '名前'
+        account_id: 'アカウント名'
+        password: 'パスワード'
+        password_confirmation: 'パスワード(確認)'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  defaults:
+    login: 'ログイン'
+    signup: '登録'
+    logout: 'ログアウト'
+    site_title: 'New moon whises'
+    message:
+      not_authenticated: 'ログインしてください'
+      created: '%{item}を作成しました'
+      not_created: '%{item}を作成できませんでした'
+      updated: '%{item}を更新しました'
+      not_updated: '%{item}を更新できませんでした'
+      deleted: '%{item}を削除しました'
+      delete_alert: '本当に実行してよろしいですか？'
+      password_reset: 'パスワードリセット手順を送信しました'
+      password_reset_success: 'パスワードが変更されました'
+      not_authorized: '権限がありません'


### PR DESCRIPTION
### 内容
+ 翻訳ファイル`ja.yml`をActiveRecord用とビューファイル用に分けて追加しました(a4dcfd26f6a9e0754bf5118ca9ef028c492f7fcb)。
+ 翻訳ファイルの内容を用い、フォームの名称、エラーおよびフラッシュメッセージの内容が日本語表示されるよう変更しました(0c9f27d9a74e1f3a62d93452c5b8576ae6cc557e)。

### 確認手順
+ すでに作成済みの新規登録ページにて翻訳ファイルが適用されていることを確認

### 確認結果
<img width="436" alt="スクリーンショット 2022-09-01 17 45 29" src="https://user-images.githubusercontent.com/99260932/187872277-6cf90647-8f1a-4d16-ae86-652fe22f49a8.png">

### Issue
close #43 