### PR TITLE
LINEアカウントでのログイン機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/.env
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'sorcery'
 
 # Environments
 gem 'config'
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     dry-configurable (0.15.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
@@ -366,6 +370,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  dotenv-rails
   enum_help
   factory_bot_rails
   html2slim

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,0 +1,32 @@
+class OauthsController < ApplicationController
+  def oauth
+    login_at(auth_params[:provider])
+  end
+
+  def callback
+    provider = auth_params[:provider]
+    if @user = login_from(provider)
+      redirect_to root_path, notice:(t'.login_success', item: provider.titleize)
+    else
+      begin
+        @user = create_from(provider)
+        reset_session
+        auto_login(@user)
+        redirect_to root_path, notice: (t'.login_success', item: provider.titleize)
+      rescue
+        redirect_to root_path, alert: (t'.login_failed', item: provider.titleize)
+      end
+    end
+  end
+
+  private
+
+  def auth_params
+    params.permit(:code, :provider, :error, :state)
+  end
+
+  # Rails7で追加されたOpen Redirect protectionを無効化するためSorceryのメソッドをオーバーライド
+  def login_at(provider_name, args = {})
+    redirect_to sorcery_login_url(provider_name, args), allow_other_host: true
+  end
+end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  # 現状LINEログインしか想定していないが、今後変更の可能性もあるためWiki通りhas_manyアソシエーションにて設定
+  has_many :authentications, dependent: :destroy
+  accepts_nested_attributes_for :authentications
+
   validates :name, presence: true, length: { maximum: 30 }
   validates :account_id, presence: true, uniqueness: true, length: { maximum: 30 }
 

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -2,3 +2,4 @@ h1 StaticPages#top
 p Find me in app/views/static_pages/top.html.slim
 button.btn.btn-square.loading
 = button_to t('defaults.logout'), logout_path, method: :delete
+= link_to 'LINEログイン', auth_at_provider_path(provider: :line)

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :external]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -80,7 +80,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = %i[line]
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -219,12 +219,16 @@ Rails.application.config.sorcery.configure do |config|
   # config.salesforce.scope = "full"
   # config.salesforce.user_info_mapping = {:email => "email"}
 
-  # config.line.key = ""
-  # config.line.secret = ""
-  # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
-  # config.line.scope = "profile"
-  # config.line.bot_prompt = "normal"
-  # config.line.user_info_mapping = {name: 'displayName'}
+  config.line.key = ENV.fetch('LINE_CHANNEL_KEY')
+  config.line.secret = ENV.fetch('LINE_CHANNEL_SECRET')
+  config.line.callback_url = Settings.sorcery[:line_callback_url]
+  config.line.scope = 'profile'
+  config.line.bot_prompt = 'aggressive'
+  config.line.user_info_mapping = {
+    name: 'displayName',
+    account_id: 'userId',
+    email: 'userId'
+  }
 
   
   # For information about Discord API
@@ -543,7 +547,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -34,3 +34,7 @@ ja:
     update:
       change_success: 'パスワードを再設定しました'
       change_failed: 'パスワードを再設定できませんでした'
+  oauths:
+    callback:
+      login_success: '%{item}でログインしました'
+      login_failed: '%{item}でログインできませんでした'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,8 @@ Rails.application.routes.draw do
   delete '/logout', to: 'user_sessions#destroy'
   resources :users, only: %i[new create]
   resources :password_resets, only: %i[new create edit update]
+
+  post 'oauth/callback', to: 'oauths#callback'
+  get 'oauth/callback', to: 'oauths#callback'
+  get 'oauths/oauth', to: 'oauths#oauth', as: :auth_at_provider
 end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+sorcery:
+  line_callback_url: 'https://new-moon-wishes.herokuapp.com/oauth/callback?provider=line'

--- a/db/migrate/20220902140229_sorcery_external.rb
+++ b/db/migrate/20220902140229_sorcery_external.rb
@@ -1,0 +1,12 @@
+class SorceryExternal < ActiveRecord::Migration[7.0]
+  def change
+    create_table :authentications do |t|
+      t.string :user_id, :provider, :uid, null: false
+
+      t.timestamps                        null: false
+    end
+
+    add_index :authentications, [:provider, :uid]
+    add_index :authentications, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_01_200027) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_02_140229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "authentications", force: :cascade do |t|
+    t.string "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+    t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false

--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :authentication do
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Authentication, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 内容
+ SorceryのExternalによるLINEログインで必要なAuthenticationsテーブルを作成し(4d16628fce79026fa9a40aceefdd7bc565d6a59e)、AuthenticationモデルにてUsersテーブルとのhas_manyアソシエーションを設定しました(bd4dd0b2b1965b40f92cf75497c53b9a3f528f5a)。
+ LINE Developersコンソールで提供されたLINEログインのためのLINE KEYおよびLINE SECRETを環境変数として設定するため、dotenv-rails(Gem)をインストールしました(2f9e43172128361c570c676189b2a95a02801e30)。
+ Sorceryの設定にてLINEログインを有効化し、Oauthsコントローラーおよびルーティング、ビューファイル内にLINEログインのリンクを追加しました(745314caa03ae3f0158f0328e72767beb2d83d96, 92fc84f69c0da034ddd2aa5949fd15c29f4496df)。

### 確認手順
1. LINEログインはSSL化されている必要があるため、開発環境に[ngrok](https://ngrok.com/)をインストール
2. ngrokアカウントの作成
3. トークンを用いてアカウントとPCを連携
4. Rails側で設定されているDNSリバインディング攻撃対策を解除するため、一時的に`config/environments/development.rb`に`config.host.clear`を追加
5. `ngrok http 3000`にてURL生成し、外部アクセス有効化(無償アカウントのため、1つのURLでは2時間まで接続可)
6. ngrokにより発行される一時的なURLを用いたコールバックURLをLINE Developers側・アプリ側に登録
7. 上記対応後、static_pages#topに追加したLINEログインのリンクよりLINEログイン機能が正常に動作することを確認

### 確認結果
<img width="977" alt="スクリーンショット 2022-09-03 7 04 51" src="https://user-images.githubusercontent.com/99260932/188244269-31870136-9f45-404b-a72b-6ea1b6fa71a3.png">
<img width="465" alt="スクリーンショット 2022-09-03 7 03 32" src="https://user-images.githubusercontent.com/99260932/188244280-ee7d0e96-646c-4b29-80b7-c2e5d120a7a1.png">

### 備考
Rails 7.0より[Open Redirect protection機能](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to)が追加され、オープンリダイレクトが保護される。これにより、Sorceryによる`login_at`メソッド内に記述されたリダイレクトが無効になってしまったため、上記機能が無効化されるよう`allow_other_host: true`を付加してメソッドをオーバーライドした。
```
def login_at(provider_name, args = {})
    redirect_to sorcery_login_url(provider_name, args), allow_other_host: true
end
```

### Issue
close #51 