### PR TITLE
願いごとに付随するジャンル整理用タグの保存機能の追加

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -18,6 +18,6 @@ class DeclarationsController < ApplicationController
   def declaration_collection_params
     params
       .require(:form_declaration_collection)
-      .permit(declarations_attributes: Form::Declaration::REGISTRABLE_ATTRIBUTES)
+      .permit(declarations_attributes: [:message, :is_shared, { declaration_tags: [] }])
   end
 end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,6 +1,7 @@
 class Declaration < ApplicationRecord
   belongs_to :wish, optional: true
   has_many :declaration_tags, dependent: :destroy
+  has_many :tags, through: :declaration_tags, source: :tag
 
   validates :message, length: { maximum: 100 }
   validates :come_true, presence: true

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,5 +1,6 @@
 class Declaration < ApplicationRecord
   belongs_to :wish, optional: true
+  has_many :declaration_tags, dependent: :destroy
 
   validates :message, length: { maximum: 100 }
   validates :come_true, presence: true

--- a/app/models/declaration_tag.rb
+++ b/app/models/declaration_tag.rb
@@ -1,0 +1,6 @@
+class DeclarationTag < ApplicationRecord
+  belongs_to :declaration_id
+  belongs_to :tag_id
+
+  validates :tag_id, uniqueness: { scope: :declaration_id }
+end

--- a/app/models/declaration_tag.rb
+++ b/app/models/declaration_tag.rb
@@ -1,6 +1,6 @@
 class DeclarationTag < ApplicationRecord
-  belongs_to :declaration_id
-  belongs_to :tag_id
+  belongs_to :declaration
+  belongs_to :tag
 
   validates :tag_id, uniqueness: { scope: :declaration_id }
 end

--- a/app/models/form/base.rb
+++ b/app/models/form/base.rb
@@ -1,6 +1,0 @@
-class Form::Base
-  include ActiveModel::Model
-  include ActiveModel::Callbacks
-  include ActiveModel::Validations
-  include ActiveModel::Validations::Callbacks
-end

--- a/app/models/form/declaration.rb
+++ b/app/models/form/declaration.rb
@@ -1,3 +1,0 @@
-class Form::Declaration < Declaration
-  REGISTRABLE_ATTRIBUTES = %i[wish_id message come_true is_shared]
-end

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -53,12 +53,13 @@ class Form::DeclarationCollection
   private
 
   def wish_is_not_created?
-    @wish = @current_user.wishes.find_by(moon_id: 1)
+    latest_newmoon = Moon.latest
+    @wish = @current_user.wishes.find_by(moon_id: latest_newmoon.id)
     if @wish.nil?
-      @wish = @current_user.wishes.build(moon_id: 1)
+      @wish = @current_user.wishes.build(moon_id: latest_newmoon.id)
       true
     else
-      errors.add(:base, '今回の新月の願いごとはすでに宣言されています')
+      errors.add(:base, "今回の#{latest_newmoon.zodiac_sign.name}新月の願いごとはすでに宣言されています")
       false
     end
   end

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -59,7 +59,7 @@ class Form::DeclarationCollection
       @wish = @current_user.wishes.build(moon_id: latest_newmoon.id)
       true
     else
-      errors.add(:base, "今回の#{latest_newmoon.zodiac_sign.name}新月の願いごとはすでに宣言されています")
+      errors.add(:base, "今回の#{latest_newmoon.zodiac_sign.name_i18n}新月の願いごとはすでに宣言されています")
       false
     end
   end

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -1,33 +1,46 @@
-class Form::DeclarationCollection < Form::Base
+class Form::DeclarationCollection
+  include ActiveModel::Model
   include ActiveModel::Attributes
+  include ActiveModel::Callbacks
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
 
-  DEFAULT_ITEM_COUNT = 5
-  attr_accessor :wish, :declarations
+  DEFAULT_ITEM_COUNT = 2
 
-  validate :wish_is_not_created?
-  validate :declaration_validate
+  attr_accessor :declarations, :declaration_tags
+
+  validate :less_than_two_declarations?
 
   def initialize(current_user = nil, attributes = {})
-    super(attributes)
     @current_user = current_user
-    self.declarations = DEFAULT_ITEM_COUNT.times.map { Form::Declaration.new } unless declarations.present?
+    self.declarations = DEFAULT_ITEM_COUNT.times.map { Declaration.new } unless declarations.present?
+    super(attributes)
   end
 
   def declarations_attributes=(attributes)
-    self.declarations = attributes.map do |_, declaration_attributes|
-      Form::Declaration.new(declaration_attributes)
+    self.declarations = attributes.map do |_, attribute|
+      if attribute[:declaration_tags].present?
+        declaration = Declaration.new(attribute.except(:declaration_tags))
+        declaration.tag_ids = attribute[:declaration_tags].map(&:to_i)
+        declaration
+      else
+        Declaration.new(attribute)
+      end
     end
   end
 
   def save
-    return false unless valid?
+    return false unless wish_is_not_created?
 
     ActiveRecord::Base.transaction do
-      @wish.save
+      @wish.save!
       declarations.each do |declaration|
         next if declaration.message.blank?
 
         declaration.wish_id = @wish.id
+        return false if invalid?
+
+        # Tagについてもここで同時に保存される
         declaration.save!
       end
       true
@@ -40,9 +53,9 @@ class Form::DeclarationCollection < Form::Base
   private
 
   def wish_is_not_created?
-    @wish = @current_user.wishes.find_by(moon_id: 2)
+    @wish = @current_user.wishes.find_by(moon_id: 1)
     if @wish.nil?
-      @wish = @current_user.wishes.build(moon_id: 2)
+      @wish = @current_user.wishes.build(moon_id: 1)
       true
     else
       errors.add(:base, '今回の新月の願いごとはすでに宣言されています')
@@ -53,14 +66,7 @@ class Form::DeclarationCollection < Form::Base
   def less_than_two_declarations?
     if declarations.pluck(:message).compact_blank.size < 2
       errors.add(:base, '願いごとは2個以上で宣言してください')
-      true
+      false
     end
-  end
-
-  def declaration_validate
-    return false if less_than_two_declarations?
-
-    results = declarations.map { |declaration| declaration.valid?(:declaration_form) }
-    results.all?
   end
 end

--- a/app/models/moon.rb
+++ b/app/models/moon.rb
@@ -4,4 +4,9 @@ class Moon < ApplicationRecord
 
   validates :newmoon_time, presence: true
   validates :fullmoon_time, presence: true
+
+  def self.latest
+    declaration_time_moon = find_by(newmoon_time: Time.current.ago(2.days)..Time.current)
+    find_by(newmoon_time: Time.current..Time.current + 29.day + 12.hours) if declaration_time_moon.nil?
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :declaration_tags, dependent: :destroy
+  has_many :tagged_declarations, through: :declaration_tags, source: :declaration
+
+  validates :name, presence: true, length: { maximum: 15 }
+end

--- a/app/views/declarations/new.html.slim
+++ b/app/views/declarations/new.html.slim
@@ -9,6 +9,9 @@
     div
       = f.label :is_shared
       = f.check_box :is_shared, {}, 1, 0
+    div
+      = f.collection_check_boxes :declaration_tags, Tag.all, :id, :name, { include_hidden: false }
+      hr
       hr
   div
     = fb.submit '願いごとをする'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,3 +13,18 @@ ja:
         message: 'メッセージ'
         come_true: '成就'
         is_shared: '公開'
+  enums:
+    zodiac_sign:
+      name:
+        aries: '牡羊座'
+        taurus: '牡牛座'
+        gemini: '双子座'
+        cancer: '蟹座'
+        leo: '獅子座'
+        virgo: '乙女座'
+        libra: '天秤座'
+        scorpio: '蠍座'
+        sagittarius: '射手座'
+        capricorn: '山羊座'
+        aquarius: '水瓶座'
+        pisces: '魚座'

--- a/db/migrate/20220914130312_create_tags.rb
+++ b/db/migrate/20220914130312_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220914131050_create_declaration_tags.rb
+++ b/db/migrate/20220914131050_create_declaration_tags.rb
@@ -1,0 +1,12 @@
+class CreateDeclarationTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :declaration_tags do |t|
+      t.references :declaration, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :declaration_tags, %i[declaration_id tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_05_145417) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_14_130312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -42,6 +42,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_05_145417) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["zodiac_sign_id"], name: "index_moons_on_zodiac_sign_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_130312) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_14_131050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -23,6 +23,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_130312) do
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "declaration_tags", force: :cascade do |t|
+    t.bigint "declaration_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id", "tag_id"], name: "index_declaration_tags_on_declaration_id_and_tag_id", unique: true
+    t.index ["declaration_id"], name: "index_declaration_tags_on_declaration_id"
+    t.index ["tag_id"], name: "index_declaration_tags_on_tag_id"
   end
 
   create_table "declarations", force: :cascade do |t|
@@ -84,6 +94,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_130312) do
     t.index ["name"], name: "index_zodiac_signs_on_name", unique: true
   end
 
+  add_foreign_key "declaration_tags", "declarations"
+  add_foreign_key "declaration_tags", "tags"
   add_foreign_key "declarations", "wishes"
   add_foreign_key "moons", "zodiac_signs"
   add_foreign_key "wishes", "moons"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,3 +11,22 @@ CSV.foreach('db/csv/moons.csv', headers: true) do |row|
     fullmoon_time: row['fullmoon_time']
   )
 end
+
+Tag.create!(
+  [
+    { id: 1, name: '人生' },
+    { id: 2, name: '仕事' },
+    { id: 3, name: '人間関係' },
+    { id: 4, name: '勉強' },
+    { id: 5, name: '恋愛' },
+    { id: 6, name: 'パートナーシップ' },
+    { id: 7, name: 'セクシャリティ' },
+    { id: 8, name: '家庭' },
+    { id: 9, name: '生活' },
+    { id: 10, name: '健康' },
+    { id: 11, name: 'お金' },
+    { id: 12, name: '趣味' },
+    { id: 13, name: 'ダイエット' },
+    { id: 14, name: 'マインド' }
+  ]
+)

--- a/spec/factories/declaration_tags.rb
+++ b/spec/factories/declaration_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :declaration_tag do
+    declaration_id { nil }
+    tag_id { nil }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { 'MyString' }
+  end
+end

--- a/spec/models/declaration_tag_spec.rb
+++ b/spec/models/declaration_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DeclarationTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 内容
+ Tagsテーブル、TagsおよびDeclarationsテーブルの中間テーブルとなるDeclaration_Tagsテーブルを作成し(0c4866045d8cf0cffdb0eea14518f36b18f51c54, 1af1aeefdb628379e602488368a91f3d1cdfbe7d)、作成した2テーブルのバリデーション・アソシエーション設定を行いました(75e889a3026f85d79c08ce38c19457c0b13d801a)。
+ Tagsテーブルに必要な初期データをseedファイルに追加しました(4c4b0857a0057f2f37591adbeedea426dc079b8f)。
+ すで実装済みのWishおよびDeclarationの同時保存に加えて、Declarationに紐づくTagの同時保存機能を追加しました(18783c819cebed216c416c820f9950b1029c75b4)。
+ 直近の新月を検索するクラスメソッドを追加しました(aea7661b3c53f01c79f92ac2d760ed15b43c8b1c)。
+ enum_help(Gem)を使用して、Zodiac_signsテーブルの各サイン(星座)名の日本語表示に対応しました(d4203104a1cabca8ee3341e467a6b950432ef7c8)。

### 確認手順および確認結果
`localhost:3000/declarations/new`にアクセスし、
+ チェックボックスにチェック済みのタグが願いごとにアソシエーションする形で同時に保存されていることを確認
<img width="921" alt="スクリーンショット 2022-09-17 22 12 04" src="https://user-images.githubusercontent.com/99260932/190894247-fedb12f3-6b89-44a0-994b-1d6ef1ee5df9.png">
<img width="915" alt="スクリーンショット 2022-09-17 22 12 56" src="https://user-images.githubusercontent.com/99260932/190894255-4cc76977-4f01-44d6-80a8-af4c78488baa.png">
<img width="1031" alt="スクリーンショット 2022-09-17 22 14 21" src="https://user-images.githubusercontent.com/99260932/190894261-868bc2c1-2284-47de-8bc5-36f6b5490fc3.png">

+ Flashメッセージで直近の新月のサイン名が日本語にて表示されていることを確認
<img width="410" alt="スクリーンショット 2022-09-18 17 44 48" src="https://user-images.githubusercontent.com/99260932/190894267-475bc9db-4477-46ba-bd6c-4372297552d8.png">
<img width="1032" alt="スクリーンショット 2022-09-18 18 01 53" src="https://user-images.githubusercontent.com/99260932/190894349-4b1543cf-1804-44d4-bfc0-74d7981d0841.png">

### Issue
close #28