### PR TITLE
願いごとの振り返り同時編集機能の追加

### DIFF
--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -1,0 +1,29 @@
+class ReflectionsController < ApplicationController
+  def edit
+    set_wish
+    @form = Form::DeclarationCollection.new(current_user, wish: @wish)
+  end
+
+  def update
+    set_wish
+    @form = Form::DeclarationCollection.new(current_user, wish_params, wish: @wish)
+    if @form.update(wish_params)
+      redirect_to edit_reflection_path(@wish), notice: t('.updated')
+    else
+      flash[:alert] = t('.not_updated')
+      render :edit
+    end
+  end
+
+  private
+
+  def set_wish
+    @wish = current_user.wishes.find(params[:id])
+  end
+
+  def wish_params
+    params
+      .require(:wish)
+      .permit(:id, :memo, declarations_attributes: %i[id is_shared come_true])
+  end
+end

--- a/app/views/reflections/edit.html.slim
+++ b/app/views/reflections/edit.html.slim
@@ -1,0 +1,15 @@
+- content_for :title, t('.title')
+/= #{@form.wish.zodiac_sign.name_i18n}
+= form_with model: @form, url: reflection_path, method: :patch do |fb|
+  = render 'shared/error_messages', object: fb.object
+  h3 #{fb.object.wish.zodiac_sign.name_i18n}新月(#{l(fb.object.wish.moon.newmoon_time)})
+  = fb.fields_for :declarations do |f|
+    = render 'shared/error_messages', object: f.object
+    div
+      = f.object.message
+      br
+      => f.collection_radio_buttons :come_true, Declaration.come_trues_i18n, :first, :last, { checked: f.object.come_true }
+      hr
+  = fb.text_area :memo, value: fb.object.wish.memo, placeholder: '感想などのメモが記録できます'
+  div
+    = fb.submit '振り返りおわり'

--- a/app/views/wishes/index.html.slim
+++ b/app/views/wishes/index.html.slim
@@ -7,6 +7,8 @@
       - dec.tags.each do |tag|
         => tag.name
       br
+    = link_to '振り返る', edit_reflection_path(wish)
+    br
     = link_to '編集', edit_wish_path(wish)
     br
     = button_to '削除', wish_path(wish), method: :delete

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -28,6 +28,11 @@ ja:
         capricorn: '山羊座'
         aquarius: '水瓶座'
         pisces: '魚座'
+    declaration:
+      come_true:
+        wished: '願い中'
+        fulfilled: '成就'
+        removed: '不必要'
   time:
     formats:
       default: "%Y/%m/%d %H:%M"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -54,3 +54,9 @@ ja:
       not_created: '願いごとの再宣言ができませんでした'
     destroy:
       destroyed: '願いごとをなかったことにしました'
+  reflections:
+    edit:
+      title: '振り返りをする'
+    update:
+      updated: '振り返りをしました'
+      not_updated: '振り返りができませんでした'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :password_resets, only: %i[new create edit update]
   resources :wishes, only: %i[index new create edit update destroy]
+  resources :reflections, only: %i[edit update]
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'


### PR DESCRIPTION
### 内容
+ 宣言した願いごとが成就したか(もしくは不必要になったか)といった状況を振り返る、WishおよびDeclarationの同時編集機能を追加しました(ce7ad1bf0f5194e826069603987f49dd0e6f5c92)。
具体的にはWishesテーブルにあるmemoカラム、Declarationsテーブルにあるcome_trueカラムのみに対する編集機能となります。`reflections_controller.rb`を別途作成して処理を実行しています。
+ 上記に伴い、必要な翻訳情報を追加しました(286314d9122d9d8e39667f6a6e31a0788bbf565c)。

### 確認手順および確認結果
+ `localhost:3000/wishes`にアクセスし、「振り返る」リンクより編集画面に移行できることを確認　
<img width="430" alt="スクリーンショット 2022-09-25 12 35 52" src="https://user-images.githubusercontent.com/99260932/192127131-2d7b5a61-5450-43fe-8ea5-2cd564e235aa.png">
<img width="428" alt="スクリーンショット 2022-09-25 12 27 18" src="https://user-images.githubusercontent.com/99260932/192127166-6a9c90d2-cb92-4447-9345-eae3aca8fb98.png">

+ `localhost:3000/reflections/XX/edit`にて、願いごと成就の状況を入力し正常に記録されること、ログにおいても正常にSQLが発行されていることを確認
<img width="430" alt="スクリーンショット 2022-09-25 12 28 24" src="https://user-images.githubusercontent.com/99260932/192127187-7d8e1207-3a03-4b7b-b875-65d7471932f9.png">
<img width="430" alt="スクリーンショット 2022-09-25 12 28 59" src="https://user-images.githubusercontent.com/99260932/192127189-7e0946de-1f7b-4ee4-9919-8fbff2780475.png">
<img width="1168" alt="スクリーンショット 2022-09-25 12 29 42" src="https://user-images.githubusercontent.com/99260932/192127193-fca4cb0b-a265-40b7-838f-1f8d42106561.png">

### Issue
close #32 
close #33 (本機能で振り返りの編集も可能なため)