### PR TITLE
他ユーザーの願いごと一覧表示および応援機能の追加

### DIFF
--- a/app/controllers/cheers_controller.rb
+++ b/app/controllers/cheers_controller.rb
@@ -2,7 +2,7 @@ class CheersController < ApplicationController
   def index
     @latest_moon = Moon.latest
     @moon_sign = @latest_moon.zodiac_sign
-    @other_declarations = Declaration.eager_load([{ wish: :zodiac_sign }, { wish: :user }, :tags, :cheers]).order(updated_at: :desc).where.not(user: { id: current_user.id }).where.not(come_true: 'removed').where(is_shared: 'true')
+    @other_declarations = Declaration.eager_load([{ wish: :zodiac_sign }, { wish: :user }, :tags, :cheers]).shared_other_declarations(current_user)
   end
 
   def create

--- a/app/controllers/cheers_controller.rb
+++ b/app/controllers/cheers_controller.rb
@@ -2,6 +2,12 @@ class CheersController < ApplicationController
   def index
     @latest_moon = Moon.latest
     @moon_sign = @latest_moon.zodiac_sign
-    @other_declarations = Declaration.eager_load(wish: %i[moon user]).eager_load(:tags).where.not(user: { id: current_user.id }).where(is_shared: 'true').where(moon: { id: @latest_moon.id })
+    @other_declarations = Declaration.eager_load([{ wish: :zodiac_sign }, { wish: :user }, :tags, :cheers]).order(updated_at: :desc).where.not(user: { id: current_user.id }).where.not(come_true: 'removed').where(is_shared: 'true')
+  end
+
+  def create
+    @cheered_declaration = Declaration.find(params[:declaration_id])
+    current_user.cheered_declarations << @cheered_declaration
+    redirect_back fallback_location: cheers_path, notice: t('.created')
   end
 end

--- a/app/controllers/cheers_controller.rb
+++ b/app/controllers/cheers_controller.rb
@@ -1,0 +1,7 @@
+class CheersController < ApplicationController
+  def index
+    @latest_moon = Moon.latest
+    @moon_sign = @latest_moon.zodiac_sign
+    @other_declarations = Declaration.eager_load(wish: %i[moon user]).eager_load(:tags).where.not(user: { id: current_user.id }).where(is_shared: 'true').where(moon: { id: @latest_moon.id })
+  end
+end

--- a/app/models/cheer.rb
+++ b/app/models/cheer.rb
@@ -1,0 +1,6 @@
+class Cheer < ApplicationRecord
+  belongs_to :user
+  belongs_to :declaration
+
+  validates :user_id, uniqueness: { scope: :declaration_id }
+end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -11,4 +11,6 @@ class Declaration < ApplicationRecord
   validates :wish_id, presence: true
 
   enum come_true: { wished: 0, fulfilled: 1, removed: 2 }
+
+  scope :shared_other_declarations, ->(current_user) { order(updated_at: :desc).where.not(user: { id: current_user.id }).where.not(come_true: 'removed').where(is_shared: 'true') }
 end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -2,6 +2,8 @@ class Declaration < ApplicationRecord
   belongs_to :wish, optional: true
   has_many :declaration_tags, dependent: :destroy
   has_many :tags, through: :declaration_tags, source: :tag
+  has_many :cheers
+  has_many :cheered_users, through: :cheers, source: :user
 
   validates :message, length: { maximum: 100 }
   validates :come_true, presence: true

--- a/app/models/moon.rb
+++ b/app/models/moon.rb
@@ -6,7 +6,7 @@ class Moon < ApplicationRecord
   validates :fullmoon_time, presence: true
 
   def self.latest
-    declaration_time_moon = find_by(newmoon_time: Time.current.ago(2.days)..Time.current)
-    find_by(newmoon_time: Time.current..Time.current + 29.day + 12.hours) if declaration_time_moon.nil?
+    latest_moon = find_by(newmoon_time: Time.current.ago(2.days)..Time.current)
+    latest_moon.present? ? latest_moon : find_by(newmoon_time: Time.current..Time.current + 29.day + 12.hours)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,8 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 7 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  def cheered?(declaration)
+    cheered_declarations.map(&:id).include?(declaration.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :wishes, dependent: :destroy
+  has_many :cheers, dependent: :destroy
+  has_many :cheered_declarations, through: :cheers, source: :declaration
   # 現状LINEログインしか想定していないが、今後変更の可能性もあるためWiki通りhas_manyアソシエーションにて設定
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications

--- a/app/views/cheers/index.html.slim
+++ b/app/views/cheers/index.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, t('.title')
+h3 #{@moon_sign.name_i18n}新月(#{l(@latest_moon.newmoon_time)})
+hr
+- @other_declarations.each do |declaration|
+  = declaration.message
+  br
+  - declaration.tags.each do |tag|
+    => tag.name
+  br
+  hr

--- a/app/views/cheers/index.html.slim
+++ b/app/views/cheers/index.html.slim
@@ -1,10 +1,18 @@
 - content_for :title, t('.title')
-h3 #{@moon_sign.name_i18n}新月(#{l(@latest_moon.newmoon_time)})
+h3 #{t('.title')}
 hr
 - @other_declarations.each do |declaration|
+  = declaration.wished? ? "&#127761;".html_safe : "&#127765;".html_safe
   = declaration.message
   br
+  p #{declaration.wish.zodiac_sign.name_i18n}新月
   - declaration.tags.each do |tag|
     => tag.name
   br
+  - if declaration.fulfilled?
+    p 成就ずみ！
+  - elsif current_user.cheered?(declaration)
+    p 応援ずみ！(#{declaration.cheers.map(&:id).count})
+  - else
+    = button_to '応援する', cheers_path(declaration_id: declaration.id), method: :post
   hr

--- a/app/views/shared/_flash_messages.html.slim
+++ b/app/views/shared/_flash_messages.html.slim
@@ -1,2 +1,3 @@
 - flash.each do |message_type, message|
+  - next if message_type == 'allow_other_host'
   p #{message_type}:#{message}

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,3 +60,6 @@ ja:
     update:
       updated: '振り返りをしました'
       not_updated: '振り返りができませんでした'
+  cheers:
+    index:
+      title: 'みんなの願いごと'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -63,3 +63,5 @@ ja:
   cheers:
     index:
       title: 'みんなの願いごと'
+    create:
+      created: '願いごとを応援しました！'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
   resources :wishes, only: %i[index new create edit update destroy]
   resources :reflections, only: %i[edit update]
-  resources :cheers, only: %i[index]
+  resources :cheers, only: %i[index create]
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
   resources :wishes, only: %i[index new create edit update destroy]
   resources :reflections, only: %i[edit update]
+  resources :cheers, only: %i[index]
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/db/migrate/20220925143606_create_cheers.rb
+++ b/db/migrate/20220925143606_create_cheers.rb
@@ -1,0 +1,12 @@
+class CreateCheers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cheers do |t|
+      t.references :user,         null: false, foreign_key: true, type: :uuid
+      t.references :declaration,  null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :cheers, %i[user_id declaration_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_131050) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_25_143606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -23,6 +23,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_131050) do
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "cheers", force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.bigint "declaration_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id"], name: "index_cheers_on_declaration_id"
+    t.index ["user_id", "declaration_id"], name: "index_cheers_on_user_id_and_declaration_id", unique: true
+    t.index ["user_id"], name: "index_cheers_on_user_id"
   end
 
   create_table "declaration_tags", force: :cascade do |t|
@@ -94,6 +104,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_131050) do
     t.index ["name"], name: "index_zodiac_signs_on_name", unique: true
   end
 
+  add_foreign_key "cheers", "declarations"
+  add_foreign_key "cheers", "users"
   add_foreign_key "declaration_tags", "declarations"
   add_foreign_key "declaration_tags", "tags"
   add_foreign_key "declarations", "wishes"


### PR DESCRIPTION
### 内容
+ 他ユーザーが公開設定としたDeclaration(願い中・成就済みの願いごと)一覧を表示する機能を追加しました(24a0750b742c09577efa01d07a6a867fbfd70db5)。
+ 上記を絞り込むscopeを設定しました(42be74b0f93b6720094ae71d927cceec89454f4e)。
+ 一覧画面から他ユーザーの願いごとを応援する機能(実質的にはいいね機能と同等のもの)を追加しました(7daf556bef555d9e3adc5093786f42f294796d4b, b249b42297e746ffd7c59c31d7d958f3d072e848, 00648a67474ef0e316791c54042ce6a7082d25af)。
+ 直近の新月を検索するクラスメソッドが新月を迎えてから2日以内の場合に返り値がnilとなってしまっている状態を修正しました(6ef6859bf78b3c139311bacd0e6772b8c87e1c3b)。
+ 応援機能を実行、処理成功時にFlashメッセージに`allow_other_host: false`と表示されてしまう状態を非表示となるよう修正しました(0fddca8ae69e8b84468fdfd4dbd7e60955d4670a)。

### 確認方法および確認結果
+ `localhost:3000/cheers`にアクセスし、ログイン中ユーザー以外のユーザーの公開設定済み願いごとかつ願い中・成就済みとなっているものが表示されていること、成就済みの場合は満月の絵文字が表示されていることを確認
<img width="382" alt="スクリーンショット 2022-09-28 12 33 48" src="https://user-images.githubusercontent.com/99260932/192687583-cf6e35e4-9aed-4ce5-a7f3-b5c604f1040f.png">

+ 上記画面「応援する」リンクを押下すると、処理が実行され、「応援ずみ！」の表示と総応援数が表示されることを確認
<img width="385" alt="スクリーンショット 2022-09-28 12 34 35" src="https://user-images.githubusercontent.com/99260932/192687596-fe66dbda-15bf-4dff-b650-275c0ac0f1b3.png">

### 備考
+ 応援機能を実行、処理成功時にFlashメッセージに`allow_other_host: false`と表示されてしまう状態については、Rails 7.0で導入された[Open Redirect protection機能](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to)の実行が影響しているものと考えられる。現状は`flash`に格納されてしまうため、ビューファイル側で表示をスキップするよう対応。

### Issue
close #35 
close #36 