### PR TITLE
ユーザー情報の編集・削除機能の追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,9 +7,23 @@ class ProfilesController < ApplicationController
     set_current_user
   end
 
+  def update
+    set_current_user
+    if @current_user.update(profile_params)
+      redirect_to profile_path, notice: t('defaults.message.updated', item: 'プロフィール')
+    else
+      flash[:alert] = t('defaults.message.not_updated', item: 'プロフィール')
+      render :edit
+    end
+  end
+
   private
 
   def set_current_user
     @current_user = User.find(current_user.id)
+  end
+
+  def profile_params
+    params.require(:user).permit(:name, :account_id, :email)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,15 @@
+class ProfilesController < ApplicationController
+  def show
+    set_current_user
+  end
+
+  def edit
+    set_current_user
+  end
+
+  private
+
+  def set_current_user
+    @current_user = User.find(current_user.id)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    @current_user = User.find(current_user.id)
+    @current_user.destroy!
+    redirect_to root_path, notice: t('.destroyed')
+  end
+
   private
 
   def user_params

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -1,1 +1,21 @@
 - content_for :title, "#{@current_user.name}さんのプロフィール編集"
+= form_with model: @current_user, url: profile_path do |f|
+  = render 'shared/error_messages', object: f.object
+  = f.label :name
+  = f.text_field :name
+  br
+  - if @current_user.crypted_password.present?
+    = f.label :account_id
+    = f.text_field :account_id
+    br
+    = f.label :email
+    = f.text_field :email
+    br
+  = f.submit '更新する'
+br
+- if @current_user.crypted_password.present?
+  p パスワード変更
+  p 現在登録されているアドレス宛にリセットメールを送信します。
+  = form_with url: password_resets_path do |f|
+    = hidden_field_tag :email, @current_user.email
+    = f.submit 'リセットメールを送る'

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -1,0 +1,1 @@
+- content_for :title, "#{@current_user.name}さんのプロフィール編集"

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -1,0 +1,11 @@
+- content_for :title, t('.title')
+h3 #{t('.title')}
+p 登録情報
+p = User.human_attribute_name(:name)
+p = @current_user.name
+- if current_user.crypted_password.present?
+	p = User.human_attribute_name(:account_id)
+	p = @current_user.account_id
+	p = User.human_attribute_name(:email)
+	p = @current_user.email
+p = link_to '編集', edit_profile_path

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -9,3 +9,4 @@ p = @current_user.name
 	p = User.human_attribute_name(:email)
 	p = @current_user.email
 p = link_to '編集', edit_profile_path
+p = button_to '全情報削除', user_path(@current_user), method: :delete

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -1,5 +1,13 @@
-h1 StaticPages#top
-p Find me in app/views/static_pages/top.html.slim
+h1 NEW MOON WISHES
+p トップページです(仮)
+hr
+h2 MENU
+ul
+	li = link_to 'マイプロフィール', profile_path
+	li = link_to '願いごとをする', new_wish_path
+	li = link_to '過去の願いごとを見る', wishes_path
+	li = link_to 'みんなの願いごとを見る', cheers_path
+br
 button.btn.btn-square.loading
 = button_to t('defaults.logout'), logout_path, method: :delete
 = link_to 'LINEログイン', auth_at_provider_path(provider: :line)

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,11 @@ ja:
   users:
     new:
       title: '新規登録'
+  profiles:
+    show:
+      title: 'マイプロフィール'
+    edit:
+      title: 'プロフィール編集'
   user_sessions:
     new:
       title: 'ログイン'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,8 @@ ja:
   users:
     new:
       title: '新規登録'
+    destroy:
+      destroyed: 'ご利用いただきありがとうございました(情報はすべて削除されました)'
   profiles:
     show:
       title: 'マイプロフィール'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create destroy]
+  resource :profile, only: %i[show edit update]
   resources :password_resets, only: %i[new create edit update]
   resources :wishes, only: %i[index new create edit update destroy]
   resources :reflections, only: %i[edit update]


### PR DESCRIPTION
### 内容
+ ユーザーのプロフィール確認画面を追加しました(f21ecc166ce60cb50a966f8b46628621d8c5c737)。
+ ユーザーのプロフィール編集機能を追加しました(d7292d1bff44ddc829ee63518877d594dfeae379)。
+ ユーザーの情報削除機能を追加しました(35e4b7648bb993b7b5e40f573cb262d6da2030ed)。

 ### 確認方法および確認結果
+ `localhost:3000/profile`にアクセスし、ログイン中ユーザーのプロフィール情報が閲覧できることを確認
<img width="366" alt="スクリーンショット 2022-09-28 18 58 28" src="https://user-images.githubusercontent.com/99260932/192751985-24da72ce-9d5b-464f-a006-07c10b685de5.png">

+ 上記の「編集」リンクより、プロフィール編集画面に遷移し内容を編集できることを確認
+ 名前・アカウント名が正しくない場合は更新ができないことを確認
<img width="368" alt="スクリーンショット 2022-09-28 18 59 01" src="https://user-images.githubusercontent.com/99260932/192752143-0372d98b-515d-4527-834a-20623b6446b2.png">

+ バリデーションを通過した場合はプロフィール内容を更新できることを確認
<img width="365" alt="スクリーンショット 2022-09-28 19 00 04" src="https://user-images.githubusercontent.com/99260932/192753202-72c25d25-7a8a-441e-ab5e-c0f22e8bc1a0.png">

<img width="363" alt="スクリーンショット 2022-09-28 19 00 20" src="https://user-images.githubusercontent.com/99260932/192752569-340b8fb8-93ef-4c8a-9772-6c6f71603501.png">

+ 「全情報削除」リンクより、ユーザーに関するすべての情報が削除されることを確認
Usersテーブルに関連するWishes, Declarations, Declaration_Tags, Cheesテーブルも連動して削除されることを確認
<img width="560" alt="スクリーンショット 2022-09-28 19 00 45" src="https://user-images.githubusercontent.com/99260932/192752717-e14d5d7d-befd-4b47-bc46-21c86cb3a114.png">
<img width="1157" alt="スクリーンショット 2022-09-28 19 01 20" src="https://user-images.githubusercontent.com/99260932/192753263-a8c3de04-cbbe-46db-9ec3-b293174f8441.png">

### Issue
close #21 
close #22 