### PR TITLE
新月および満月時にLINEプッシュ通知を送信する機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ gem 'dotenv-rails'
 # LINE Messaging API SDK
 gem 'line-bot-api'
 
+# Active Job
+gem 'delayed_job_active_record'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ gem 'line-bot-api'
 
 # Active Job
 gem 'delayed_job_active_record'
+# cron
+gem 'whenever', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'sorcery'
 gem 'config'
 gem 'dotenv-rails'
 
+# LINE Messaging API SDK
+gem 'line-bot-api'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,11 @@ GEM
       reline (>= 0.3.1)
     debug_inspector (1.1.0)
     deep_merge (1.2.2)
+    delayed_job (4.1.11)
+      activesupport (>= 3.0, < 8.0)
+    delayed_job_active_record (4.1.7)
+      activerecord (>= 3.0, < 8.0)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.5.0)
     digest (3.1.0)
     dotenv (2.8.1)
@@ -371,6 +376,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  delayed_job_active_record
   dotenv-rails
   enum_help
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
+    line-bot-api (1.25.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -377,6 +378,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   letter_opener_web
+  line-bot-api
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -359,6 +360,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -398,6 +401,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  whenever
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/line_notifications_controller.rb
+++ b/app/controllers/line_notifications_controller.rb
@@ -1,0 +1,13 @@
+class LineNotificationsController < ApplicationController
+  def update
+    current_user.change_notification_status(notification_params)
+    redirect_to profile_path, notice: t('.updated')
+  end
+
+  private
+
+  def notification_params
+    params.permit(:need_newmoon_msg, :need_fullmoon_msg)
+  end
+end
+

--- a/app/jobs/line_notification_job.rb
+++ b/app/jobs/line_notification_job.rb
@@ -1,0 +1,13 @@
+class LineNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(line_uid, message)
+    client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV['LINE_BOT_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_BOT_CHANNEL_TOKEN']
+    }
+
+    response = client.push_message(line_uid, message)
+    p response
+  end
+end

--- a/app/models/moon.rb
+++ b/app/models/moon.rb
@@ -1,5 +1,6 @@
 class Moon < ApplicationRecord
   has_many :wishes
+  has_many :wished_users , through: :wishes, source: :user
   belongs_to :zodiac_sign
 
   validates :newmoon_time, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,6 @@ class User < ApplicationRecord
   end
 
   def change_notification_status(params)
-    debugger
     if params[:need_newmoon_msg]
       self.need_newmoon_msg = params[:need_newmoon_msg].include?('true') ? :true : :false
     elsif params[:need_fullmoon_msg]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,14 @@ class User < ApplicationRecord
       user.password_confirmation = user.password
     end
   end
+
+  def change_notification_status(params)
+    debugger
+    if params[:need_newmoon_msg]
+      self.need_newmoon_msg = params[:need_newmoon_msg].include?('true') ? :true : :false
+    elsif params[:need_fullmoon_msg]
+      self.need_fullmoon_msg = params[:need_fullmoon_msg].include?('true') ? :true : :false
+    end
+    self.save
+  end
 end

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -14,7 +14,20 @@ h3 LINE連携
 	= image_tag @current_user.picture_url, size: '50x50'
 	- if @current_user.crypted_password.present? && @current_user.email.present?
 		= button_to 'LINE連携解除', oauth_path(@oauth.id), method: :delete
+	
+	- if @current_user.need_newmoon_msg?
+		p 新月の日に通知する
+		= button_to '解除', line_notification_path(@current_user, need_newmoon_msg: :false), method: :patch
+	- else
+		p 新月の日に通知しない
+		= button_to '通知', line_notification_path(@current_user, need_newmoon_msg: :true), method: :patch
 
+	- if @current_user.need_fullmoon_msg?
+		p 満月の日に通知する
+		= button_to '解除', line_notification_path(@current_user, need_fullmoon_msg: :false), method: :patch
+	- else
+		p 満月の日に通知しない
+		= button_to '通知', line_notification_path(@current_user, need_fullmoon_msg: :true), method: :patch
 
 - else
 	p LINEの連携をします。

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,8 @@ module NewMoonWishesApp
 
     # FormObjectの読み込み
     config.autoload_paths += Dir.glob("#{config.root}/app/models/form/**/*")
+
+    # Active JobのアダプタにDelayed Jobを設定
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -35,3 +35,4 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
+      only_time: "%H:%M"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -74,3 +74,6 @@ ja:
       title: 'みんなの願いごと'
     create:
       created: '願いごとを応援しました！'
+  line_notifications:
+    update:
+      updated: 'LINE通知設定を変更しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :reflections, only: %i[edit update]
   resources :cheers, only: %i[index create]
   resources :oauths, only: %i[destroy]
+  resources :line_notifications, only: %i[update]
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,9 @@
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+set :environment, :development
+set :output, "#{Rails.root}/log/cron.log"
+job_type :rake, "export PATH=\"$HOME/.rbenv/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
+
+every 1.day, at: '7:00 am' do
+  rake 'moon_notification:push_line_message'
+end

--- a/db/migrate/20221004120113_create_delayed_jobs.rb
+++ b/db/migrate/20221004120113_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/migrate/20221004133018_add_columns_to_users.rb
+++ b/db/migrate/20221004133018_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :need_newmoon_msg,  :boolean, null: false, default: false
+    add_column :users, :need_fullmoon_msg, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_120113) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_133018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,6 +98,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_120113) do
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "picture_url"
     t.string "line_name"
+    t.boolean "need_newmoon_msg", default: false, null: false
+    t.boolean "need_fullmoon_msg", default: false, null: false
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_30_070525) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_120113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -53,6 +53,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_30_070525) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["wish_id"], name: "index_declarations_on_wish_id"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "moons", force: :cascade do |t|

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -1,21 +1,15 @@
 namespace :moon_notification do
   desc 'New-moon-wishesのLINEBotにて新月の通知'
   task :push_line_message => :environment do
-    client ||= Line::Bot::Client.new { |config|
-      config.channel_secret = ENV['LINE_BOT_CHANNEL_SECRET']
-      config.channel_token = ENV['LINE_BOT_CHANNEL_TOKEN']
-    }
-
-    # Test送信
-    target_user = User.preload(:authentications).find('61d37e98-6c51-4e08-8ac4-6f717bbceecb')
-    # target_users.each do |user|
+    # 抽出する新月は後で修正
+    target_users = Moon.find(1).wished_users.preload(:authentications).where(need_newmoon_msg: :true)
+    target_users.each do |user|
       message = {
         type: 'text',
-        text: "#{target_user.name}さん、今日は新月です。願いごとを宣言してみませんか？https://new-moon-wishes.herokuapp.com"
+        text: "#{user.name}さん、今日は新月です。願いごとを宣言してみませんか？https://new-moon-wishes.herokuapp.com"
       }
-      line_uid = target_user.authentications.find_by(provider: 'line').uid
-      response = client.push_message(line_uid, message)
-      p response
-    # end
+      line_uid = user.authentications.find_by(provider: 'line').uid
+      LineNotificationJob.perform_later(line_uid, message)
+    end
   end
 end

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -1,0 +1,21 @@
+namespace :moon_notification do
+  desc 'New-moon-wishesのLINEBotにて新月の通知'
+  task :push_line_message => :environment do
+    client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV['LINE_BOT_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_BOT_CHANNEL_TOKEN']
+    }
+
+    # Test送信
+    target_user = User.preload(:authentications).find('61d37e98-6c51-4e08-8ac4-6f717bbceecb')
+    # target_users.each do |user|
+      message = {
+        type: 'text',
+        text: "#{target_user.name}さん、今日は新月です。願いごとを宣言してみませんか？https://new-moon-wishes.herokuapp.com"
+      }
+      line_uid = target_user.authentications.find_by(provider: 'line').uid
+      response = client.push_message(line_uid, message)
+      p response
+    # end
+  end
+end

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -1,15 +1,116 @@
 namespace :moon_notification do
-  desc 'New-moon-wishesのLINEBotにて新月の通知'
+  desc 'LINEBotにて新月・満月のプッシュ通知'
   task :push_line_message => :environment do
-    # 抽出する新月は後で修正
-    target_users = Moon.find(1).wished_users.preload(:authentications).where(need_newmoon_msg: :true)
+    newmoon = Moon.preload(:zodiac_sign).find_by(newmoon_time: Time.current.all_day)
+    fullmoon = Moon.preload(:zodiac_sign).find_by(fullmoon_time: Time.current.all_day)
+
+    if newmoon.present?
+      target_users = newmoon.wished_users.preload(:authentications).where(need_newmoon_msg: :true)
+      send_line_notifications(target_users, newmoon, '新月')
+    elsif fullmoon.present?
+      target_users = fullmoon.wished_users.preload(:authentications).where(need_fullmoon_msg: :true)
+      send_line_notifications(target_users, fullmoon, '満月')
+    else
+      p '該当なし'
+    end
+  end
+
+  def send_line_notifications(target_users, moon, moon_type)
     target_users.each do |user|
       message = {
-        type: 'text',
-        text: "#{user.name}さん、今日は新月です。願いごとを宣言してみませんか？https://new-moon-wishes.herokuapp.com"
-      }
+        type: 'flex',
+        altText: "#{moon.zodiac_sign.name_i18n}#{moon_type}のお知らせ",
+        contents: flex_message(user, moon, moon_type)
+       }
       line_uid = user.authentications.find_by(provider: 'line').uid
       LineNotificationJob.perform_later(line_uid, message)
+    end
+  end
+
+  # 画像は後で差し替え予定
+  def flex_message(user, moon, moon_type)
+    {
+      "type": "bubble",
+      "hero": {
+        "type": "image",
+        "url": "https://scdn.line-apps.com/n/channel_devcenter/img/fx/01_1_cafe.png",
+        "size": "full",
+        "aspectRatio": "16:9",
+        "aspectMode": "cover",
+        "action": {
+          "type": "uri",
+          "uri": "https://new-moon-wishes.herokuapp.com/"
+        }
+      },
+      "body": {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [
+          {
+            "type": "text",
+            "text": "#{moon_type}をお知らせします",
+            "weight": "bold",
+            "size": "lg",
+            "align": "center"
+          },
+          {
+            "type": "box",
+            "layout": "vertical",
+            "margin": "lg",
+            "spacing": "sm",
+            "contents": [
+              {
+                "type": "box",
+                "layout": "baseline",
+                "spacing": "sm",
+                "contents": [
+                  {
+                    "type": "text",
+                    "text": text_content(user, moon, moon_type),
+                    "wrap": true,
+                    "color": "#666666",
+                    "size": "sm",
+                    "flex": 5,
+                    "align": "center"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "footer": {
+        "type": "box",
+        "layout": "vertical",
+        "spacing": "sm",
+        "contents": [
+          {
+            "type": "button",
+            "style": "link",
+            "height": "sm",
+            "action": {
+              "type": "uri",
+              "label": "#{moon_type.include?('新月') ? '願いごとを宣言する' : '願いごとを振り返る'}",
+              "uri": "#{moon_type.include?('新月') ? 'https://new-moon-wishes.herokuapp.com/wishes/new' : 'https://new-moon-wishes.herokuapp.com/wishes'}"
+            }
+          },
+          {
+            "type": "box",
+            "layout": "vertical",
+            "contents": [],
+            "margin": "sm"
+          }
+        ],
+        "flex": 0
+      }
+    }
+  end
+
+  def text_content(user, moon, moon_type)
+    if moon_type == '新月'
+      content = "#{user.name}さん、おはようございます。今日は#{I18n.l(moon.newmoon_time, format: :only_time)}に#{moon.zodiac_sign.name_i18n}で#{moon_type}を#{moon.newmoon_time < Time.current ? '迎えました' : '迎えます'}。新月から48時間以内に願いごとを宣言してみませんか？"
+    elsif moon_type == '満月'
+      content = "#{user.name}さん、おはようございます。今日は#{I18n.l(moon.fullmoon_time, format: :only_time)}に#{moon.zodiac_sign.name_i18n}で#{moon_type}を#{moon.newmoon_time < Time.current ? '迎えました' : '迎えます'}。半年前に宣言した願いごとが達成されているか、振り返りをしてみませんか？"
     end
   end
 end

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -5,11 +5,11 @@ namespace :moon_notification do
     fullmoon = Moon.preload(:zodiac_sign).find_by(fullmoon_time: Time.current.all_day)
 
     if newmoon.present?
-      target_users = newmoon.wished_users.preload(:authentications).where(need_newmoon_msg: :true)
-      send_line_notifications(target_users, newmoon, '新月')
+      target_users = User.preload(:authentications).where(need_newmoon_msg: :true)
+      send_line_notifications(target_users, newmoon, '新月') if target_users.present?
     elsif fullmoon.present?
       target_users = fullmoon.wished_users.preload(:authentications).where(need_fullmoon_msg: :true)
-      send_line_notifications(target_users, fullmoon, '満月')
+      send_line_notifications(target_users, fullmoon, '満月') if target_users.present?
     else
       p '該当なし'
     end


### PR DESCRIPTION
### 内容
+ 新月および満月時にLINEプッシュ通知が必要かどうかのオン・オフ切り替え機能を追加しました(086f99ebbfca5d4892232bd1ef452f6bafeff03d, 4c79e4540cbbe2a0c5635508b5676f1d8d0d976a)。
+ 新月時には通知送信希望のユーザーに対して全員、満月時には約半年前の新月時に願いごとを宣言しており通知送信希望のユーザーに対してリマインドのLINEプッシュ通知をFlex Messageにて送信する機能を追加しました(b0e50618aa5e086cab4137b9419f51d0438a0136, 9da8e026fd55ae6ea62cc1a3ed3a430fd71dc6e3, 29eacd44f1a1832baa5b19b2d43109cbfbeedea6, c1cedb6568ea142b217c4dc56cb0d7b2e98d554d)。
+ 上記の各対象者はrakeタスクで抽出し、送信処理についてはDelayed Jobへ渡して処理しています(0686d53c54b095c6a90d1a4a5d63aef7cda6ff8f, 2eacf9a32b54a114b97b835cc285294fa2d35c98, 5ba2e1384ce2c37aa076ec04324ad971c89f92b6, e7a8654630869f2a76fbe2c7269de483dbe7c33c)。

### 確認方法および確認結果
+ `localhost:3000/profile`でLINE通知のオン・オフ切り替え表示がされていることを確認
<img width="327" src="https://user-images.githubusercontent.com/99260932/194244312-e0ef5a42-5ed7-4032-bd55-09ce24a63cc8.png">

+ 上記画面の「新月の日に通知する」状態から「解除」リンク押下によって「新月の日に通知しない」に状態変化していることを確認
<img width="329" src="https://user-images.githubusercontent.com/99260932/194244720-0ca529ad-ef10-4acd-957b-4b005f6cf013.png">

+ 上記画面の「満月の日に通知する」状態から「解除」リンク押下によって「新月の日に通知しない」に状態変化していることを確認　
<img width="330" src="https://user-images.githubusercontent.com/99260932/194244851-da13389d-0237-4a44-acf0-9d80b672c1c7.png">

+ 一時的に対象者抽出方法を特定の新月・満月として、ターミナル上でrakeタスクを実行し(`rake moon_notification:push_line_message`)、LINEプッシュ通知が送信されることを確認
<img width="330" src="https://user-images.githubusercontent.com/99260932/194245855-2a96076e-609d-43c8-b8f4-a44107b1d73c.png">

### Issue
close #37 
close #38 