### PR TITLE
ヘッダー(ナビバー)およびボトムナビゲーションの追加

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,7 @@ html
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
     link rel ="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css"
   body
+    = render 'shared/navbar'
     = render 'shared/flash_messages'
     = yield
     - if logged_in?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,4 +12,5 @@ html
   body
     = render 'shared/flash_messages'
     = yield
-    = render 'shared/bottom_navbar'
+    - if logged_in?
+      = render 'shared/bottom_navbar'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,8 @@ html
     = csp_meta_tag
     = stylesheet_link_tag "application"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
+    link rel ="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css"
   body
     = render 'shared/flash_messages'
     = yield
+    = render 'shared/bottom_navbar'

--- a/app/views/shared/_bottom_navbar.html.slim
+++ b/app/views/shared/_bottom_navbar.html.slim
@@ -1,4 +1,4 @@
-.btm-nav.btm-nav-sm.bg-indigo-50
+.btm-nav.btm-nav-sm.bg-indigo-50.md:hidden
   = link_to new_wish_path do
     i.fas.fa-moon.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
     span.btm-nav-label.text-indigo-900

--- a/app/views/shared/_bottom_navbar.html.slim
+++ b/app/views/shared/_bottom_navbar.html.slim
@@ -11,7 +11,16 @@
     i.fas.fa-user-friends.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
     span.btm-nav-label.text-indigo-900
       | 願いを応援
-  = link_to profile_path
+  /= link_to profile_path
     i.fas.fa-info-circle.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
     span.btm-nav-label.text-indigo-900
       | 設定
+  .dropdown.dropdown-top.dropdown-end.flex.block[tabindex="0"]
+    i.fas.fa-info-circle.block.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+    span.btm-nav-label.block.text-indigo-900
+      | 設定
+    ul.dropdown-content.menu.pt-1.pd-1.bg-indigo-50.rounded.w-32.md:w-52[tabindex="0"]
+      li.text-sm.text-indigo-900
+        = button_to t('defaults.logout'), logout_path, method: :delete
+      li.text-sm.text-indigo-900
+        = link_to 'プロフィール', profile_path

--- a/app/views/shared/_bottom_navbar.html.slim
+++ b/app/views/shared/_bottom_navbar.html.slim
@@ -1,0 +1,17 @@
+.btm-nav.btm-nav-sm.bg-indigo-50
+  = link_to new_wish_path do
+    i.fas.fa-moon.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+    span.btm-nav-label.text-indigo-900
+      | 願いごと
+  = link_to wishes_path do
+    i.fas.fa-calendar-alt.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+    span.btm-nav-label.text-indigo-900
+      | 振り返り
+  = link_to cheers_path
+    i.fas.fa-user-friends.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+    span.btm-nav-label.text-indigo-900
+      | 願いを応援
+  = link_to profile_path
+    i.fas.fa-info-circle.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+    span.btm-nav-label.text-indigo-900
+      | 設定

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -1,0 +1,53 @@
+.navbar.bg-indigo-50.text-indigo-900
+  .flex-1.px-3
+    = link_to logged_in? ? wishes_path : root_path do 
+      text-lg.font-bold.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+        | CLARUS
+  - if logged_in?
+    .flex.justify-end.hidden.md:flex
+      .flex.items-stretch
+        = link_to new_wish_path do
+          label.btn.btn-ghost.rounded-btn.flex-col
+            i.fas.fa-moon.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            | 願いごと
+        = link_to wishes_path do
+          label.btn.btn-ghost.rounded-btn.flex-col
+            i.fas.fa-calendar-alt.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            | 振り返り
+        = link_to cheers_path do
+          label.btn.btn-ghost.rounded-btn.flex-col
+            i.fas.fa-user-friends.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            | 願いを応援
+        = link_to profile_path do
+          label.btn.btn-ghost.rounded-btn.flex-col
+            i.fas.fa-info-circle.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            | プロフィール
+        = button_to logout_path, method: :delete do
+          span.btn.btn-ghost.rounded-btn.flex-col
+            i.fas.fa-sign-out-alt.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            | ログアウト
+  - else
+    .flex.justify-end
+      .flex.items-stretch
+        = link_to login_path do
+          label.btn.btn-ghost.rounded-btn
+            | ログイン
+        = link_to root_path do
+          label.btn.btn-ghost.rounded-btn
+            | 使い方
+        = link_to new_user_path do
+          label.btn.btn-ghost.rounded-btn
+            | 新規登録
+        .dropdown.dropdown-end.menu-compact
+          label.btn.btn-ghost.rounded-btn[tabindex="0"]
+            i.fas.fa-info-circle
+          ul.menu.dropdown-content.p-2.shadow.bg-indigo-50.rounded.w-52.mt-4[tabindex="0"]
+            li
+              a
+                | 利用規約
+            li
+              a
+                | プライバシーポリシー
+            li
+              a
+                | お問い合わせ


### PR DESCRIPTION
### 内容
+ Tailwind CSSおよびdaisyUIを使用してヘッダー(ナビバー)およびボトムナビゲーションを追加しました(7537b8feb862fe01291620c3a97ffd88dfbc88bd, d45bbfd77a87866e91663e788b1f91c2424afbd7)。
+ Font Awsome FreeをCDNを用いて使用しました(7537b8feb862fe01291620c3a97ffd88dfbc88bd)。
+ ユーザーの使用環境およびログイン状態によってヘッダーおよびボトムナビゲーションが表示・非表示となるように出し分けを追加しました(b9c1f75a60a12eacfe7854a10324fa0a6b196ce4, d45bbfd77a87866e91663e788b1f91c2424afbd7)。

### 確認手順および確認結果
+ 横幅が768px未満の場合にログイン操作を行うと、ログイン後にナビバーの表示が消え、ボトムナビゲーションが表示されることを確認
+ 「ｉ」ボタンからドロップダウンリストが表示されることを確認
+ 「設定」ボタンからドロップダウンリストが表示されることを確認
<img width="300" alt="スクリーンショット 2022-10-10 18 04 54" src="https://user-images.githubusercontent.com/99260932/194832103-846d8920-8da9-4005-b35e-59c69ff876bf.png">　<img width="300" alt="スクリーンショット 2022-10-10 17 58 51" src="https://user-images.githubusercontent.com/99260932/194831104-178af7cf-e970-46d1-b21a-460f5c6a98fe.png">

+ 横幅が768px以上の場合にログイン操作を行うと、ログイン後にナビバーの表示が変わり、ボトムナビゲーションは表示されないことを確認
+ 「ｉ」ボタンからドロップダウンリストが表示されることを確認
<img width="320" alt="スクリーンショット 2022-10-10 17 53 13" src="https://user-images.githubusercontent.com/99260932/194831626-a6e140f1-2799-45d9-bf67-ca0ac6f85e57.png">　<img width="320" alt="スクリーンショット 2022-10-10 17 53 32" src="https://user-images.githubusercontent.com/99260932/194831635-cfd616fc-8f72-4951-93b6-6bcfbe2226bc.png">

### Issue
close #56 
close #64 