### PR TITLE
プロフィール閲覧・編集およびLINE連携画面へのCSS適用

### DIFF
--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -1,17 +1,28 @@
 - content_for :title, "#{@current_user.name}さんのプロフィール編集"
-= form_with model: @current_user, url: profile_path do |f|
-  = render 'shared/error_messages', object: f.object
-  = f.label :name
-  = f.text_field :name
-  br
-  = f.label :email
-  = f.text_field :email
-  br
-  = f.submit '更新する'
-br
-- if @current_user.crypted_password.present?
-  p パスワード変更
-  p 現在登録されているアドレス宛にリセットメールを送信します。
-  = form_with url: password_resets_path do |f|
-    = hidden_field_tag :email, @current_user.email
-    = f.submit 'リセットメールを送る'
+.container.mx-auto.text-indigo-900
+  .px-5.border-opacity-50
+    .grid.place-items-center
+      h1.place-items-center.my-6.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+        = t('.title')
+    .grid.place-items-center
+      = form_with model: @current_user, url: profile_path, class: 'w-full px-5 md:w-3/5 md:px-0' do |f|
+        = render 'shared/error_messages', object: f.object
+        .form-control
+          label.label
+            span.label-text.text-indigo-900
+              = f.label User.human_attribute_name(:name) 
+          = f.text_field :name, placeholder: '30文字以内でご入力ください', class: "input input-primary border-opacity-20 w-full mb-3"
+        .form-control
+          label.label
+            span.label-text.text-indigo-900
+              = f.label User.human_attribute_name(:email) 
+          = f.text_field :email, placeholder: '受信可能なものをご入力ください', class: "input input-primary border-opacity-20 w-full mb-3"
+        = f.submit '変更', class: "btn btn-wide w-full mt-4 mb-5"
+    - if @current_user.crypted_password.present?
+      .grid.place-items-center
+        h1.place-items-center.my-6.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+          | パスワードの変更
+        p.text-sm.w-4/5 現在登録されているアドレス宛にパスワード再設定用のメールを送信します。
+        = form_with url: password_resets_path, class: 'w-full px-5 md:w-3/5 md:px-0' do |f|
+          = hidden_field_tag :email, @current_user.email
+          = f.submit 'メール送信', class: "btn btn-wide w-full mt-8 mb-20"

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -1,35 +1,102 @@
 - content_for :title, t('.title')
-h3 #{t('.title')}
-p 登録情報
-p = User.human_attribute_name(:name)
-p = @current_user.name
-p = User.human_attribute_name(:email)
-p = @current_user.email.present? ? @current_user.email : '未登録'
-p = link_to '編集', edit_profile_path
-p = button_to '全情報削除', user_path(@current_user), method: :delete
+.container.mx-auto.text-indigo-900
+  .grid.place-items-center
+    h1.mt-6.mb-3.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+      = t('.title')
+    .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
+      .card-body.p-5
+        span.badge
+          = User.human_attribute_name(:name)
+        p.ml-3 = @current_user.name
+        span.badge
+          = User.human_attribute_name(:email)
+        p.ml-3 = @current_user.email.present? ? @current_user.email : '未登録'
+        .card-actions.justify-end.mt-3
+          = button_to user_path(@current_user), method: :delete do
+            button.btn.btn-sm.btn-outline.btn-error.font-light
+              | ユーザー削除
+          = link_to edit_profile_path do
+            button.btn.btn-sm.btn-outline.font-light
+              | 編集
+    
+    h1.mt-6.mb-3.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
+      | LINE連携
+    - if @oauth.present?
+      .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
+        .card-body.p-5
+          .flex.items-center.justify-between.pt-2
+            = image_tag @current_user.picture_url, size: '50x50', class: "mask mask-circle"
+            .flex-col.pl-2.pr-5.flex-grow
+              = @current_user.line_name
+              p.text-sm.text-gray-400 連携されています
+            - if @current_user.crypted_password.present? && @current_user.email.present?
+              = button_to oauth_path(@oauth.id), method: :delete do
+                button.btn.btn-sm.btn-outline.font-light
+                  | 解除
+          .divider.mt-3.mb-1.text-sm
+            | 現在の通知設定
+          .flex.items-center
+            - if @current_user.need_newmoon_msg?
+              = "&#127761;".html_safe
+              p 新月の日に通知する
+              = button_to line_notification_path(@current_user, need_newmoon_msg: :false), method: :patch do
+                button.btn.btn-sm.btn-outline.font-light
+                  | 解除
+            - else
+              = "&#127761;".html_safe
+              p 新月の日に通知しない
+              = button_to line_notification_path(@current_user, need_newmoon_msg: :true), method: :patch do
+                button.btn.btn-sm.btn-outline.font-light
+                  | 通知
+          .flex.items-center
+            - if @current_user.need_fullmoon_msg?
+              = "&#127765;".html_safe
+              p 満月の日に通知する
+              = button_to line_notification_path(@current_user, need_fullmoon_msg: :false), method: :patch do
+                button.btn.btn-sm.btn-outline.font-light
+                  | 解除
+            - else
+              = "&#127765;".html_safe
+              p 満月の日に通知しない
+              = button_to line_notification_path(@current_user, need_fullmoon_msg: :true), method: :patch do
+                button.btn.btn-sm.btn-outline.font-light
+                  | 通知
 
-h3 LINE連携
-- if @oauth.present?
-	= @current_user.line_name
-	= image_tag @current_user.picture_url, size: '50x50'
-	- if @current_user.crypted_password.present? && @current_user.email.present?
-		= button_to 'LINE連携解除', oauth_path(@oauth.id), method: :delete
-	
-	- if @current_user.need_newmoon_msg?
-		p 新月の日に通知する
-		= button_to '解除', line_notification_path(@current_user, need_newmoon_msg: :false), method: :patch
-	- else
-		p 新月の日に通知しない
-		= button_to '通知', line_notification_path(@current_user, need_newmoon_msg: :true), method: :patch
+    - else
+      .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
+        .card-body.p-5.items-center
+          p.text-sm.text-center.text-gray-500 現在連携されていません 
+          = link_to auth_at_provider_path(provider: :line) do
+            = image_tag 'btn_login_base.png', class: "w-36 mt-2"
+          label.modal-button.text-indigo-400.text-md.mt-2[for="my-modal-4"]
+            i.fas.fa-question-circle.pr-1
+            | 連携の方法を詳しく見る
+      .px-5.py-5.mb-12.w-4/5.sm:w-3/5.lg:w-2/5
+        p.text-sm LINEアカウントを連携されますと、新月・満月の当日をお知らせする通知を受信できるようになり、本サービスにもLINEでログインができます。
+      
 
-	- if @current_user.need_fullmoon_msg?
-		p 満月の日に通知する
-		= button_to '解除', line_notification_path(@current_user, need_fullmoon_msg: :false), method: :patch
-	- else
-		p 満月の日に通知しない
-		= button_to '通知', line_notification_path(@current_user, need_fullmoon_msg: :true), method: :patch
-
-- else
-	p LINEの連携をします。
-	p 下記手続きをすると、LINE宛に振り返りなどの通知を送信できるようになり、アプリにもLINEでログインができます。
-	= link_to 'LINEでログイン', auth_at_provider_path(provider: :line)
+input#my-modal-4.modal-toggle[type="checkbox"]
+label.modal.cursor-pointer[for="my-modal-4"]
+  label.modal-box.relative[for=""]
+    h3.mb-3.text-lg.font-bold.text-indigo-900.text-center
+      | LINEアカウント連携方法
+    h4.mt-3.mb-1.text-md.text-indigo-900
+      | 1.下記からLINEアカウントを開く
+    = link_to auth_at_provider_path(provider: :line) do
+      = image_tag 'btn_login_base.png', class: "w-36 mt-2 inline-block items-center"
+    p.text-sm.pt-4.pb-0
+      | LINEアプリ上で確認画面・注意事項が表示されますので、内容をご確認いただいた上で「許可する」を押します。
+    h4.mt-5.mb-1.text-md.text-indigo-900
+      | 2.友だち追加する
+    p.text-sm
+      | 許可後、本サービスのLINEアカウントを友だちに追加する画面が表示されますので、「友だち追加」を押します。
+    p.mt-2.text-sm.text-indigo-700
+      | ※友だち追加をされないと、通知が届きませんのでご注意ください。
+    h4.mt-5.mb-1.text-md.text-indigo-900
+      | 3.プロフィールにアカウント情報が表示されていることを確認する
+    p.text-sm
+      | ご自身のLINEアカウントが表示されていれば連携は完了です！
+    h4.mt-5.mb-1.text-md.text-indigo-900
+      | 4.LINEの通知設定をする
+    p.text-sm
+      | 通知をご希望の方は通知するボタンを押して通知をオンにしてください！

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,4 +1,5 @@
 - if object.errors.present?
-  ul
-    - object.errors.full_messages.each do |message|
-        li = message
+  - object.errors.full_messages.each do |message|
+    ul
+      li.text-sm.text-center.text-indigo-700
+        = message


### PR DESCRIPTION
### 内容
+ Tailwind CSSおよびdaisyUIを使用してプロフィール閲覧・編集およびLINE連携画面へデザインを適用しました(3a0511218756a6a7b412bcb59c9ece30485dc4a0, 69966fb5ed04ccda8cad50a4e61892aafdaeb5de)。
+ エラーメッセージのパーシャルテンプレートに対してデザインを適用しました(19cd279cff84d42069c1c7c183c43e58b99c9c2d)。

### 確認手順および確認結果
+ `http://localhost:3000/profile`にアクセスした際、LINE連携済みの場合はLINEアカウントの表示およびLINE通知設定が表示されることを確認

<img width="300" alt="スクリーンショット 2022-10-17 21 49 53" src="https://user-images.githubusercontent.com/99260932/196182348-88db76c9-5672-4539-ba5e-e6548f1c2ef5.png">

+ `http://localhost:3000/profile`にアクセスした際、LINE未連携の場合はLINE連携ボタンおよび操作方法が表示されることを確認
+ 「連携の方法を詳しく見る」リンクを押下すると、LINE連携操作方法がモーダル表示されることを確認

<img width="300" alt="スクリーンショット 2022-10-17 21 51 51" src="https://user-images.githubusercontent.com/99260932/196182498-61be0954-96b2-4833-b92f-e82b3f6fdd10.png">　<img width="300" alt="スクリーンショット 2022-10-17 21 52 11" src="https://user-images.githubusercontent.com/99260932/196182752-55589eb3-1644-4368-9d94-dd63af46a18a.png">

+ `http://localhost:3000/profile/edit`にアクセスした際、デザインが適用されていることを確認
+ バリデーションに引っかかる場合は、デザインが適用されたエラーメッセージが表示されることを確認
(※Flashメッセージについては別途対応予定)
<img width="300" alt="スクリーンショット 2022-10-17 21 50 35" src="https://user-images.githubusercontent.com/99260932/196183510-00b7711d-7cf3-4e65-8c4a-00d46389deee.png">　<img width="300" alt="スクリーンショット 2022-10-17 21 50 54" src="https://user-images.githubusercontent.com/99260932/196183525-958221a5-d3c5-4d19-a2e5-6f4caa9f4907.png">

### Issue
close #71 
close #72 