### PR TITLE
FlashメッセージへのCSS適用

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,138 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*Banner open/load animation*/
+.alert-banner {
+	-webkit-animation: slide-in-top 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+	animation: slide-in-top 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+}
+
+/*Banner close animation*/
+.alert-banner input:checked~* {
+	-webkit-animation: slide-out-top 0.5s cubic-bezier(0.550, 0.085, 0.680, 0.530) both;
+	animation: slide-out-top 0.5s cubic-bezier(0.550, 0.085, 0.680, 0.530) both;
+}
+
+/*Toast open/load animation*/
+.alert-toast {
+	-webkit-animation: slide-in-right 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+	animation: slide-in-right 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+}
+
+/*Toast close animation*/
+.alert-toast input:checked~* {
+	-webkit-animation: fade-out-right 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+	animation: fade-out-right 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
+}
+
+@-webkit-keyframes slide-in-top {
+	0% {
+		-webkit-transform: translateY(-1000px);
+		transform: translateY(-1000px);
+		opacity: 0
+	}
+
+	100% {
+		-webkit-transform: translateY(0);
+		transform: translateY(0);
+		opacity: 1
+	}
+}
+
+@keyframes slide-in-top {
+	0% {
+		-webkit-transform: translateY(-1000px);
+		transform: translateY(-1000px);
+		opacity: 0
+	}
+
+	100% {
+		-webkit-transform: translateY(0);
+		transform: translateY(0);
+		opacity: 1
+	}
+}
+
+@-webkit-keyframes slide-out-top {
+	0% {
+		-webkit-transform: translateY(0);
+		transform: translateY(0);
+		opacity: 1
+	}
+
+	100% {
+		-webkit-transform: translateY(-1000px);
+		transform: translateY(-1000px);
+		opacity: 0
+	}
+}
+
+@keyframes slide-out-top {
+	0% {
+		-webkit-transform: translateY(0);
+		transform: translateY(0);
+		opacity: 1
+	}
+
+	100% {
+		-webkit-transform: translateY(-1000px);
+		transform: translateY(-1000px);
+		opacity: 0
+	}
+}
+@-webkit-keyframes slide-in-right {
+	0% {
+		-webkit-transform: translateX(1000px);
+		transform: translateX(1000px);
+		opacity: 0
+	}
+
+	100% {
+		-webkit-transform: translateX(0);
+		transform: translateX(0);
+		opacity: 1
+	}
+}
+
+@keyframes slide-in-right {
+	0% {
+		-webkit-transform: translateX(1000px);
+		transform: translateX(1000px);
+		opacity: 0
+	}
+
+	100% {
+		-webkit-transform: translateX(0);
+		transform: translateX(0);
+		opacity: 1
+	}
+}
+
+@-webkit-keyframes fade-out-right {
+	0% {
+		-webkit-transform: translateX(0);
+		transform: translateX(0);
+		opacity: 1
+	}
+
+	100% {
+		-webkit-transform: translateX(50px);
+		transform: translateX(50px);
+		opacity: 0
+	}
+}
+
+@keyframes fade-out-right {
+	0% {
+		-webkit-transform: translateX(0);
+		transform: translateX(0);
+		opacity: 1
+	}
+
+	100% {
+		-webkit-transform: translateX(50px);
+		transform: translateX(50px);
+		opacity: 0
+	}
+}

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -4,17 +4,17 @@ class WishesController < ApplicationController
   end
 
   def new
-    @latest_newmoon = Moon.latest
-    @keywords = Trait.where(zodiac_sign_id: @latest_newmoon.zodiac_sign_id).map(&:keyword).shuffle
+    set_zodiac_keywords
     @form = Form::DeclarationCollection.new(wish: current_user.wishes.build)
   end
 
   def create
+    set_zodiac_keywords
     @form = Form::DeclarationCollection.new(current_user, declaration_collection_params)
     if @form.save
       redirect_to wishes_path, notice: t('.created')
     else
-      flash[:alert] = t('.not_created')
+      flash.now[:alert] = t('.not_created')
       render :new
     end
   end
@@ -28,7 +28,7 @@ class WishesController < ApplicationController
     if @form.update(tag_params)
       redirect_to wishes_path, notice: t('.created')
     else
-      flash[:alert] = t('.not_created')
+      flash.now[:alert] = t('.not_created')
       render :edit
     end
   end
@@ -40,6 +40,11 @@ class WishesController < ApplicationController
   end
 
   private
+
+  def set_zodiac_keywords
+    @latest_newmoon = Moon.latest
+    @keywords = Trait.where(zodiac_sign_id: @latest_newmoon.zodiac_sign_id).map(&:keyword).shuffle
+  end
 
   def declaration_collection_params
     params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def hidden_if(action)
-    return 'hidden' if params[:action] == action
+    params[:action] == action ? 'flex' : 'hidden'
   end
 
   def fullmoon_emoji_if(declaration)

--- a/app/views/shared/_declarations_form.html.slim
+++ b/app/views/shared/_declarations_form.html.slim
@@ -1,7 +1,7 @@
 = form_with model: form, class: 'w-full px-5 sm:px-0 lg:w-4/5 max-w-2xl' do |fb|
   = render 'shared/error_messages', object: fb.object
   = render 'shared/one_declaration_form', fb: fb
-  div class="#{hidden_if('edit')} flex justify-center items-center link link-hover mt-8 text-sm text-indigo-400" id="js-display-declaration-button" onclick="displayDeclarationForm(event)"
+  div class="#{hidden_if('new')} justify-center items-center link link-hover mt-8 text-sm text-indigo-400" id="js-display-declaration-button" onclick="displayDeclarationForm(event)"
     .fas.fa-plus-circle.pr-1
     | 願いごとを追加する
   = fb.submit '願いごとをする', class: "btn btn-wide w-full mt-8 mb-20"

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,5 +1,6 @@
 - if object.errors.present?
   - object.errors.full_messages.each do |message|
-    ul
-      li.text-sm.text-center.text-indigo-700
-        = message
+    ul.my-2
+      li.text-sm.text-center.text-red-400
+        i.far.fa-sad-tear.mx-1
+        | #{message}

--- a/app/views/shared/_flash_messages.html.slim
+++ b/app/views/shared/_flash_messages.html.slim
@@ -1,3 +1,29 @@
 - flash.each do |message_type, message|
   - next if message_type == 'allow_other_host'
-  p #{message_type}:#{message}
+  div[onClick="deleteAlert()"]
+    #js-alert-banner.alert-banner.w-full.fixed.top-0.md:hidden
+      input#banneralert.hidden[type="checkbox"]
+      label.close.cursor-pointer.flex.items-center.justify-between.w-full.px-3.py-2.text-indigo-700.bg-gradient-to-r.from-purple-100.via-indigo-100.to-blue-100[title="close" for="banneralert"]
+        .flex.items-center
+          i.fas.fa-bullhorn.mx-1
+          span
+            | #{message}
+        i.fas.fa-times
+
+  div[onClick="deleteAlert()"]
+    #js-alert-toast.alert-toast.fixed.z-10.hidden.md:flex.bottom-0.right-0.m-8.w-5/6.md:w-full.max-w-md
+      input#footertoast.hidden[type="checkbox"]
+      label.close.cursor-pointer.flex.items-center.justify-between.w-full.px-3.py-2.h-16.rounded.shadow-lg.shadow-indigo-900/10.text-indigo-700.bg-gradient-to-r.from-purple-100.via-indigo-100.to-blue-100[title="close" for="footertoast"]
+        .flex.items-center
+          i.fas.fa-bullhorn.mx-1
+          span
+            | #{message}
+        i.fas.fa-times.mr-1
+
+javascript:
+  function deleteAlert() {
+    setTimeout(() => {
+      document.getElementById('js-alert-banner').remove();
+      document.getElementById('js-alert-toast').remove();
+    }, 500);
+  }

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -1,4 +1,4 @@
-.navbar.bg-indigo-50.text-indigo-900
+.flex.items-center.p-1.md:p-2.w-full.h-10.md:h-14.bg-indigo-50.text-indigo-900
   .flex-1.px-3
     = link_to logged_in? ? wishes_path : root_path do 
       text-lg.font-bold.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
@@ -7,39 +7,39 @@
     .flex.justify-end.hidden.md:flex
       .flex.items-stretch
         = link_to new_wish_path do
-          label.btn.btn-ghost.rounded-btn.flex-col
-            i.fas.fa-moon.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
-            | 願いごと
+          label.btn.btn-ghost.rounded-btn.flex-col.font-normal
+            i.fas.fa-moon.text-lg.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            .text-xs 願いごと
         = link_to wishes_path do
-          label.btn.btn-ghost.rounded-btn.flex-col
-            i.fas.fa-calendar-alt.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
-            | 振り返り
+          label.btn.btn-ghost.rounded-btn.flex-col.font-normal
+            i.fas.fa-calendar-alt.text-lg.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            .text-xs 振り返り
         = link_to cheers_path do
-          label.btn.btn-ghost.rounded-btn.flex-col
-            i.fas.fa-user-friends.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
-            | 願いを応援
+          label.btn.btn-ghost.rounded-btn.flex-col.font-normal
+            i.fas.fa-user-friends.text-lg.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            .text-xs 願いを応援
         = link_to profile_path do
-          label.btn.btn-ghost.rounded-btn.flex-col
-            i.fas.fa-info-circle.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
-            | プロフィール
+          label.btn.btn-ghost.rounded-btn.flex-col.font-normal
+            i.fas.fa-info-circle.text-lg.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            .text-xs プロフィール
         = button_to logout_path, method: :delete do
-          span.btn.btn-ghost.rounded-btn.flex-col
-            i.fas.fa-sign-out-alt.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
-            | ログアウト
+          span.btn.btn-ghost.rounded-btn.flex-col.font-normal
+            i.fas.fa-sign-out-alt.text-lg.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600.mb-1
+            .text-xs ログアウト
   - else
     .flex.justify-end
-      .flex.items-stretch
+      .flex.items-center
         = link_to login_path do
-          label.btn.btn-ghost.rounded-btn
+          label.btn.btn-sm.btn-ghost.rounded-btn.px-2
             | ログイン
         = link_to root_path do
-          label.btn.btn-ghost.rounded-btn
+          label.btn.btn-sm.btn-ghost.rounded-btn.px-2
             | 使い方
         = link_to new_user_path do
-          label.btn.btn-ghost.rounded-btn
+          label.btn.btn-sm.btn-ghost.rounded-btn.px-2
             | 新規登録
         .dropdown.dropdown-end.menu-compact
-          label.btn.btn-ghost.rounded-btn[tabindex="0"]
+          label.btn.btn-sm.btn-ghost.rounded-btn[tabindex="0"]
             i.fas.fa-info-circle
           ul.menu.dropdown-content.p-2.shadow.bg-indigo-50.rounded.w-52.mt-4[tabindex="0"]
             li

--- a/app/views/shared/_one_declaration_form.html.slim
+++ b/app/views/shared/_one_declaration_form.html.slim
@@ -1,6 +1,6 @@
 = fb.fields_for :declarations do |f|
-  div class="#{hidden_if('new')}" id="js-add-declaration-form-#{f.index}"
-		.divider.mt-3.mb-1.text-sm
+  div class="hidden" id="js-add-declaration-form-#{f.index}"
+		.divider.mt-3.mb-1
 		= render 'shared/error_messages', object: f.object
 		.flex.justify-between.items-center
 			.form-control

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,8 @@ module NewMoonWishesApp
 
     # Active JobのアダプタにDelayed Jobを設定
     config.active_job.queue_adapter = :delayed_job
+
+    # バリデーション失敗時のfield_with_errorsのdivタグ自動生成を停止
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,25 @@
+const plugin = require('tailwindcss/plugin');
+
 module.exports = {
-  plugins: [require("daisyui")],
-  content: [
+    daisyui: {
+          themes: [
+            {
+              mytheme: {              
+                 "primary": "#3730a3",
+                 "secondary": "#4338ca",
+                 "accent": "#fef08a",
+                 "neutral": "#3730a3",
+                 "base-100": "#f8f8ff",
+                 "info": "#06b6d4",
+                 "success": "#16a34a",
+                 "warning": "#fcd34d",
+                 "error": "#e880b4",
+              },
+            },
+          ],
+    },
+    plugins: [require("daisyui")],
+    content: [
     './app/views/**/*.html.slim',
     './app/helpers/**/*.rb',
     './app/assets/stylesheets/**/*.css',


### PR DESCRIPTION
### 内容
+ Tailwind CSSおよびdaisyUIを使用してFlashメッセージのパーシャルテンプレートにデザインを適用しました(79697f2a171ff762ce157f1f7faf1b05fbb2ae86)。

#### 上記以外のデザイン修正
+ エラーメッセージのパーシャルテンプレートに上下の余白を追加しました(618ad1677a8bb13dc4bbb20bda3cb5f52ec32512)。
+ daisyUIのオリジナル配色テーマをTailwind CSSの設定ファイルに追加しました(47a7a874c2f4f13d0b71305ef2f0e58b0e6b7e42)。
+ バリデーション失敗時にRails側で自動生成される`field_with_errors`という名称のdivタグによりデザインが崩れるため、自動生成されないよう設定ファイルに追加しました(4d4f6e63a1827bcbdf283973d2eb7940beb49873)。

#### Fix
+ 願いごと宣言操作のバリデーション失敗後、レンダーされたビューファイル上で願いごと入力欄が10個(最大個数)表示されている状態で追加ボタンも表示されてしまっている状態および入力欄の表示崩れを修正しました(73a8f7319aaf213f69bf96deaad73cbb39fa9d17)。
+ サイン(星座)のキーワード一覧が表示されない状態を修正しました(cae84f72eba7c5a8e096fe1e6d34d0cd585573ff)。

### 確認手順および確認結果
+ アクション発生後、正しくFlashメッセージが表示されることを確認
+ レスポンシブデザインに応じて、表示されるFlashメッセージが異なることを確認
<img width="247" src="https://user-images.githubusercontent.com/99260932/198644949-fe199ef3-d0d5-467b-ba9e-7c63fc1489f0.png">　<img width="400" src="https://user-images.githubusercontent.com/99260932/198646296-86302f9b-c18a-4fbb-9b8e-c3895b1b2d39.png">

### Issue
close #79 
