### PR TITLE
確認済みのバグ修正およびビューファイルの改善

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -3,6 +3,6 @@ class GuestSessionsController < ApplicationController
     @guest_user = User.guest_generate
     auto_login(@guest_user)
 
-    redirect_to new_wish_path
+    redirect_to new_wish_path, notice: t('.created')
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -23,7 +23,7 @@ class PasswordResetsController < ApplicationController
     if @user.change_password(params[:user][:password])
       redirect_to login_path, notice: t('.change_success')
     else
-      flash[:alert] = t('.change_failed')
+      flash.now[:alert] = t('.change_failed')
       render :edit
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
     if @current_user.update(profile_params)
       redirect_to profile_path, notice: t('defaults.message.updated', item: 'プロフィール')
     else
-      flash[:alert] = t('defaults.message.not_updated', item: 'プロフィール')
+      flash.now[:alert] = t('defaults.message.not_updated', item: 'プロフィール')
       render :edit
     end
   end

--- a/app/controllers/reflections_controller.rb
+++ b/app/controllers/reflections_controller.rb
@@ -10,7 +10,7 @@ class ReflectionsController < ApplicationController
     if @form.update(wish_params)
       redirect_to wishes_path, notice: t('.updated')
     else
-      flash[:alert] = t('.not_updated')
+      flash.now[:alert] = t('.not_updated')
       render :edit
     end
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
   def top; end
+
+  def menu; end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -9,7 +9,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to(menu_path, notice: t('.login_success'))
     else
-      flash[:alert] = t('.login_failed')
+      flash.now[:alert] = t('.login_failed')
       render :new
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,9 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)
-      redirect_to root_path, notice: t('defaults.message.created', item: User.model_name.human)
+      redirect_to menu_path, notice: t('defaults.message.created', item: User.model_name.human)
     else
-      flash[:alert] = t('defaults.message.not_created', item: User.model_name.human)
+      flash.now[:alert] = t('defaults.message.not_created', item: User.model_name.human)
       render :new
     end
   end
@@ -22,9 +22,9 @@ class UsersController < ApplicationController
   def update
     @user = User.find(current_user.id)
     if @user.update(user_params)
-      redirect_to root_path, notice: t('defaults.message.created', item: User.model_name.human)
+      redirect_to profile_path, notice: t('defaults.message.created', item: User.model_name.human)
     else
-      flash[:alert] = t('defaults.message.not_created', item: User.model_name.human)
+      flash.now[:alert] = t('defaults.message.not_created', item: User.model_name.human)
       render :edit
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
   end
 
   def hidden_if(action)
-    params[:action] == action ? 'flex' : 'hidden'
+    params[:action] == action ? 'hidden' : 'flex'
   end
 
   def fullmoon_emoji_if(declaration)

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -2,7 +2,7 @@ class Declaration < ApplicationRecord
   belongs_to :wish, optional: true
   has_many :declaration_tags, dependent: :destroy
   has_many :tags, through: :declaration_tags, source: :tag
-  has_many :cheers
+  has_many :cheers, dependent: :destroy
   has_many :cheered_users, through: :cheers, source: :user
 
   validates :message, length: { maximum: 100 }

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -55,10 +55,7 @@ class Form::DeclarationCollection
     return false unless valid?
 
     ActiveRecord::Base.transaction do
-      if tag_params[:memo].present?
-        declarations.each(&:save!)
-        @wish.update!(memo: tag_params[:memo])
-      else
+      if tag_params[:memo].nil?
         declarations.each_with_index do |declaration, index|
           next if declaration.message.blank?
 
@@ -71,6 +68,9 @@ class Form::DeclarationCollection
           return false unless declaration.valid?
         end
         declarations.each(&:save!)
+      else
+        declarations.each(&:save!)
+        @wish.update!(memo: tag_params[:memo])
       end
       true
     end

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -57,7 +57,10 @@ class Form::DeclarationCollection
     ActiveRecord::Base.transaction do
       if tag_params[:memo].nil?
         declarations.each_with_index do |declaration, index|
-          next if declaration.message.blank?
+          if declaration.message.blank?
+            declaration.destroy!
+            next
+          end
 
           if tag_params[index.to_s][:declaration_tags].present?
             tags = tag_params[index.to_s][:declaration_tags][:tag_id].map(&:to_i)
@@ -66,8 +69,8 @@ class Form::DeclarationCollection
             declaration.tag_ids = []
           end
           return false unless declaration.valid?
+          declaration.save!
         end
-        declarations.each(&:save!)
       else
         declarations.each(&:save!)
         @wish.update!(memo: tag_params[:memo])

--- a/app/views/shared/_declarations_form.html.slim
+++ b/app/views/shared/_declarations_form.html.slim
@@ -7,8 +7,15 @@
   = fb.submit '願いごとをする', class: "btn btn-wide w-full mt-8 mb-20"
 
   javascript:
-    document.getElementById('js-add-declaration-form-0').style.display = "block";
-    document.getElementById('js-add-declaration-form-1').style.display = "block";
+    changeFormToOpen(0, 2);
+    if ( '#{params[:action]}' == 'edit' ) {
+      changeFormToOpen(0, #{form.declarations.count});
+    }
+    function changeFormToOpen(start_count, end_count) {
+      for (start_count; start_count < end_count; ++start_count ) {
+        document.getElementById(`js-add-declaration-form-${start_count}`).style.display = "block";
+      }
+    }
     let form_count = 2
     const displayDeclarationForm = (e) => {
       if ( form_count < 10 ) {

--- a/app/views/shared/_declarations_form.html.slim
+++ b/app/views/shared/_declarations_form.html.slim
@@ -1,15 +1,15 @@
 = form_with model: form, class: 'w-full px-5 sm:px-0 lg:w-4/5 max-w-2xl' do |fb|
   = render 'shared/error_messages', object: fb.object
   = render 'shared/one_declaration_form', fb: fb
-  div class="#{hidden_if('new')} justify-center items-center link link-hover mt-8 text-sm text-indigo-400" id="js-display-declaration-button" onclick="displayDeclarationForm(event)"
+  div class="#{hidden_if('edit')} justify-center items-center link link-hover mt-8 text-sm text-indigo-400" id="js-display-declaration-button" onclick="displayDeclarationForm(event)"
     .fas.fa-plus-circle.pr-1
     | 願いごとを追加する
   = fb.submit '願いごとをする', class: "btn btn-wide w-full mt-8 mb-20"
 
   javascript:
     changeFormToOpen(0, 2);
-    if ( '#{params[:action]}' == 'edit' ) {
-      changeFormToOpen(0, #{form.declarations.count});
+    if ( #{form.declarations.pluck(:message).compact_blank.size} > 0 ) {
+      changeFormToOpen(0, #{form.declarations.pluck(:message).compact_blank.size});
     }
     function changeFormToOpen(start_count, end_count) {
       for (start_count; start_count < end_count; ++start_count ) {

--- a/app/views/shared/_flash_messages.html.slim
+++ b/app/views/shared/_flash_messages.html.slim
@@ -1,6 +1,6 @@
 - flash.each do |message_type, message|
   - next if message_type == 'allow_other_host'
-  div[onClick="deleteAlert()"]
+  div[onClick="deleteAlert(500)"]
     #js-alert-banner.alert-banner.w-full.fixed.top-0.md:hidden
       input#banneralert.hidden[type="checkbox"]
       label.close.cursor-pointer.flex.items-center.justify-between.w-full.px-3.py-2.text-indigo-700.bg-gradient-to-r.from-purple-100.via-indigo-100.to-blue-100[title="close" for="banneralert"]
@@ -10,7 +10,7 @@
             | #{message}
         i.fas.fa-times
 
-  div[onClick="deleteAlert()"]
+  div[onClick="deleteAlert(500)"]
     #js-alert-toast.alert-toast.fixed.z-10.hidden.md:flex.bottom-0.right-0.m-8.w-5/6.md:w-full.max-w-md
       input#footertoast.hidden[type="checkbox"]
       label.close.cursor-pointer.flex.items-center.justify-between.w-full.px-3.py-2.h-16.rounded.shadow-lg.shadow-indigo-900/10.text-indigo-700.bg-gradient-to-r.from-purple-100.via-indigo-100.to-blue-100[title="close" for="footertoast"]
@@ -21,9 +21,10 @@
         i.fas.fa-times.mr-1
 
 javascript:
-  function deleteAlert() {
+  function deleteAlert(disapperTime) {
     setTimeout(() => {
       document.getElementById('js-alert-banner').remove();
       document.getElementById('js-alert-toast').remove();
-    }, 500);
+    }, disapperTime);
   }
+  deleteAlert(3000);

--- a/app/views/wishes/index.html.slim
+++ b/app/views/wishes/index.html.slim
@@ -88,7 +88,7 @@
             | みんなの願いごとを見てみる
 
   .grid.place-items-center.my-5
-    - if current_user.email.include?('guest_')
+    - if current_user.email.include?('guest_') && @wishes.present?
       p.text-sm.text-indigo-400 この願いごとを記録した状態で
       = link_to edit_user_path(current_user) do
         button.btn.btn-sm.btn-outline.font-light.mt-2

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,6 +33,9 @@ ja:
       login_failed: 'ログインできませんでした'
     destroy:
       logout_success: 'ログアウトしました'
+  guest_sessions:
+    create:
+      created: 'ゲストユーザーとしてログインしました'
   password_resets:
     create:
       reset_success: 'パスワードリセットメールを送信しました'


### PR DESCRIPTION
### 内容
#### 願いごとの振り返り
+ メモ欄が空欄だとエラーとなり振り返りの登録処理ができない状態を修正しました(840b7869799c3fad16ec9e0795d588e06e495cf9)。

#### 願いごとの宣言・編集
+ 入力欄が適切に表示されない状態を修正しました(8dc059d87e9aaa38bba4f42f13c34d40350822af, 68cfb895092cba1e38b65b06065fdcdf7e52e84e)。
+ 編集時に願いごとの内容(メッセージ)が空欄だった場合、該当項目が削除されるよう修正しました(2cea9fc6eaf5f76ccdec1c3d73395da6d2b95041)。

#### フラッシュメッセージ
+ 処理失敗時のフラッシュメッセージの表示を`flash`から`flash.now`に修正しました(b17369e82210d723a68d8a9ef42175e32b6ca1b0, 3f9d84f59aa796b501b56a1767799e1888e9e5a4)。
+ ゲストログイン時のフラッシュメッセージの文言を追加しました(4ebd0deb4150af5704acc03f026aaa21f6083f5a, a2139b6a29ff5f9ae1229434c5186f5f95184a22)。
+ フラッシュメッセージの表示時間を3秒にし、その後は操作がなくても非表示となるよう修正しました(470d23abebf1666e14420db536a7e21ad2226ea1)。

#### その他
+ ゲストログイン時に願いごとの宣言をしなかった場合、ユーザー登録のリンクが表示されないよう修正しました(640dd83ebd803ad9a7830f19ed6b31deca127f6c)。
+ 願いごとの削除時に関連する応援の記録も同時削除されるよう`dependent: :destroy`を追加しました(65e82ec467b99bf082b5570aa659f81aba00877a)。
+ 静的ページ(`menu`)のアクションについてコントーラーに記載しました(c3439fe96232d421d724a21352c21a6c043677aa)。

### Issue
close #90 