### PR TITLE
確認済みのバグ修正

### DIFF
--- a/app/controllers/line_notifications_controller.rb
+++ b/app/controllers/line_notifications_controller.rb
@@ -1,5 +1,5 @@
 class LineNotificationsController < ApplicationController
-  skip_before_action :require_login
+  before_action :require_login
 
   def update
     current_user.change_notification_status(notification_params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,6 @@ class User < ApplicationRecord
     elsif params[:need_fullmoon_msg]
       self.need_fullmoon_msg = params[:need_fullmoon_msg].include?('true') ? :true : :false
     end
-    self.save
+    self.save(validate: false)
   end
 end


### PR DESCRIPTION
### 内容
+ LINE通知切り替え設定処理時にメールアドレスなどのバリデーションが入りエラーとなってしまう状態だったため、この処理でのバリデーションはスキップするよう修正しました。また、未ログイン状態でもアクセスできるような設定になっていたため、こちらも修正しました(a86e0e590427d26970ad4ed49b1990f54d0869c5)。