### PR TITLE
アファメーション機能の追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -138,7 +138,7 @@
 }
 
 #particles-js { 
-    position: absolute;
+    position: fixed;
     width: 100%;
     height: 100%;
 	z-index: -1;
@@ -151,7 +151,7 @@
 
 .glowAnime span {
 	opacity: 0;
-	font-size: clamp(12px, 1vw, 20px);
+	font-size: clamp(13px, 1vw, 20px);
 }
 
 /*アニメーションで透過を0から1に変化させtext-shadowをつける*/

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -136,3 +136,42 @@
 		opacity: 0
 	}
 }
+
+#particles-js { 
+    position: absolute;
+    width: 100%;
+    height: 100%;
+	z-index: -1;
+    background-color: #150757;
+    background-image: url("");
+    background-repeat: repeat;
+    background-size: 20%;
+    background-position: 50% 50%;
+}
+
+.glowAnime span {
+	opacity: 0;
+	font-size: clamp(12px, 1vw, 20px);
+}
+
+/*アニメーションで透過を0から1に変化させtext-shadowをつける*/
+.glowAnime.glow span{
+	animation:glow_anime_on 1s ease-out forwards;
+}
+
+@keyframes glow_anime_on{
+	0% {
+		opacity: 0;
+		text-shadow: 0 0 0 #fff, 0 0 0 #fff;
+	}
+
+	50% {
+		opacity: 1;
+		text-shadow: 0 0 10px #fff, 0 0 15px #fff;
+	}
+
+	100% {
+		opacity: 1;
+		text-shadow: 0 0 0 #fff, 0 0 0 #fff;
+	}
+}

--- a/app/controllers/affirmations_controller.rb
+++ b/app/controllers/affirmations_controller.rb
@@ -1,0 +1,5 @@
+class AffirmationsController < ApplicationController
+  def show
+    @wish = current_user.wishes.find(params[:id])
+  end
+end

--- a/app/controllers/affirmations_controller.rb
+++ b/app/controllers/affirmations_controller.rb
@@ -1,4 +1,6 @@
 class AffirmationsController < ApplicationController
+  layout 'affirmation'
+
   def show
     @wish = current_user.wishes.find(params[:id])
   end

--- a/app/views/affirmations/show.html.slim
+++ b/app/views/affirmations/show.html.slim
@@ -1,0 +1,3 @@
+- @wish.declarations.each do |declaration|
+	= declaration.message
+	br

--- a/app/views/affirmations/show.html.slim
+++ b/app/views/affirmations/show.html.slim
@@ -1,3 +1,63 @@
-- @wish.declarations.each do |declaration|
-	= declaration.message
-	br
+script[src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"]
+#particles-js
+.container.mx-auto.mb-14
+  .grid.place-items-center
+    h1.place-items-center.my-7.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-300.via-indigo-200.to-blue-300
+    	| MY DECLARATIONS
+		.text-center.text-sm
+			| #{@wish.zodiac_sign.name_i18n}新月
+			br
+			| #{l(@wish.moon.newmoon_time)}
+  .grid.place-items-center.mx-10.my-auto
+		.text-indigo-100.text-center.leading-5.glowAnime.hidden
+			- @wish.declarations.each do |declaration|
+				= declaration.message + '&'
+  .grid.place-items-center.mx-10.my-auto
+
+
+javascript:
+	particlesJS.load('particles-js', '/assets/particles.json', function() {
+		console.log('callback - particles.js config loaded');
+	});
+
+	// glowAnimeにglowというクラス名を付ける定義
+	function GlowAnimeControl() {
+		const glowAnime = document.querySelectorAll('.glowAnime');
+		for (var i = 0; i < glowAnime.length; i++) {
+			var elemPos = glowAnime[i].getBoundingClientRect().top + window.pageYOffset - 50;
+			var scroll = window.pageYOffset;
+			var windowHeight = window.innerHeight;
+			if (scroll >= elemPos - windowHeight) {
+				glowAnime[i].classList.remove("hidden");
+				glowAnime[i].classList.add("glow");
+			} else {
+				glowAnime[i].classList.remove("glow");
+			}
+		}
+	}
+
+	var element = document.querySelectorAll(".glowAnime");
+	window.addEventListener('load', (event) => {
+		for (var m = 0; m < element.length; m++) {
+			var text = element[m].innerText;
+			var textbox = "";
+			text.split('').forEach(function (t, i) {
+				if (t !== " " && t !== "&") {
+					if (i < 10) {
+						textbox += '<span style="animation-delay: .' + i + 's;">' + t + '</span>';
+					} else {
+						var n = i / 10;
+						textbox += '<span style="animation-delay: ' + n + 's;">' + t + '</span>';
+					}
+				} else if (t == "&") {
+					textbox += '</br></br>';
+				} else {
+					textbox += t;
+				}
+			});
+			textbox += '</br>';
+			element[m].innerHTML = textbox;
+		};
+
+		GlowAnimeControl();
+	});

--- a/app/views/affirmations/show.html.slim
+++ b/app/views/affirmations/show.html.slim
@@ -1,28 +1,34 @@
 script[src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"]
-#particles-js
-.container.mx-auto.mb-14
-  .grid.place-items-center
-    h1.place-items-center.my-7.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-300.via-indigo-200.to-blue-300
-    	| MY DECLARATIONS
-		.text-center.text-sm
-			| #{@wish.zodiac_sign.name_i18n}新月
-			br
-			| #{l(@wish.moon.newmoon_time)}
-  .grid.place-items-center.mx-10.my-auto
-		.text-indigo-100.text-center.leading-5.glowAnime.hidden
-			- @wish.declarations.each do |declaration|
-				= declaration.message + '&'
-  .grid.place-items-center.mx-10.my-auto
 
+#screenshot-target
+	#particles-js
+	.container.mx-auto.mb-14
+		.grid.place-items-center
+			h1.place-items-center.my-7.text-xl.text-bold.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-300.via-indigo-200.to-blue-300
+				| MY DECLARATIONS
+				.text-center.text-sm.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-300.via-indigo-200.to-blue-300
+					| #{@wish.zodiac_sign.name_i18n}新月 #{l(@wish.moon.newmoon_time)}
+		.grid.place-items-center.mx-10.my-auto
+			.text-indigo-100.text-center.leading-5.glowAnime.hidden
+				- @wish.declarations.each do |declaration|
+					- next if declaration.fulfilled? || declaration.removed?
+					= declaration.message + '&'
+		.btm-nav.btm-nav-sm.bg-transparent.h-16
+			#menuButton.flex.flex-row.hidden
+				= link_to affirmation_path(@wish) do
+					button.btn.btn-sm.btn-outline.font-light.text-indigo-200.mr-2[onclick="reloadGlowAnime()"]
+						| もう一度
+				= link_to wishes_path do
+					button.btn.btn-sm.btn-outline.font-light.text-indigo-200
+						| 終わる
 
 javascript:
 	particlesJS.load('particles-js', '/assets/particles.json', function() {
 		console.log('callback - particles.js config loaded');
 	});
-
-	// glowAnimeにglowというクラス名を付ける定義
+	
+	const glowAnime = document.querySelectorAll('.glowAnime');
 	function GlowAnimeControl() {
-		const glowAnime = document.querySelectorAll('.glowAnime');
 		for (var i = 0; i < glowAnime.length; i++) {
 			var elemPos = glowAnime[i].getBoundingClientRect().top + window.pageYOffset - 50;
 			var scroll = window.pageYOffset;
@@ -37,6 +43,7 @@ javascript:
 	}
 
 	var element = document.querySelectorAll(".glowAnime");
+	var animationTime = 0;
 	window.addEventListener('load', (event) => {
 		for (var m = 0; m < element.length; m++) {
 			var text = element[m].innerText;
@@ -44,9 +51,9 @@ javascript:
 			text.split('').forEach(function (t, i) {
 				if (t !== " " && t !== "&") {
 					if (i < 10) {
-						textbox += '<span style="animation-delay: .' + i + 's;">' + t + '</span>';
+						textbox += '<span style="animation-delay: 1.' + i + 's;">' + t + '</span>';
 					} else {
-						var n = i / 10;
+						var n = (i + 10) / 10;
 						textbox += '<span style="animation-delay: ' + n + 's;">' + t + '</span>';
 					}
 				} else if (t == "&") {
@@ -54,10 +61,14 @@ javascript:
 				} else {
 					textbox += t;
 				}
+			animationTime = i;
 			});
-			textbox += '</br>';
 			element[m].innerHTML = textbox;
 		};
+
+    setTimeout(() => {
+      document.getElementById('menuButton').classList.remove("hidden");
+    }, animationTime * 100 + 3000);
 
 		GlowAnimeControl();
 	});

--- a/app/views/layouts/affirmation.html.slim
+++ b/app/views/layouts/affirmation.html.slim
@@ -1,0 +1,17 @@
+doctype html
+html
+  head
+    title
+      = page_title(yield(:title))
+    meta[name="viewport" content="width=device-width,initial-scale=1"]
+    = csrf_meta_tags
+    = csp_meta_tag
+    = favicon_link_tag "favicon.ico"
+    = stylesheet_link_tag "application"
+    = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
+    link rel ="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css"
+    link rel="apple-touch-icon" href="#{image_path("apple-touch-icon.png")}" sizes="180x180" type="image/png"
+    link rel="android-touch-icon" href="#{image_path("android-touch-icon.png")}" sizes="192x192" type="image/png"
+    = render 'layouts/google_analytics'
+  body
+    = yield

--- a/app/views/wishes/index.html.slim
+++ b/app/views/wishes/index.html.slim
@@ -49,8 +49,8 @@
                 button.btn.btn-sm.btn-outline.font-light
                   | 振り返る
               .flex-row
-                = link_to '#' do
-                  button.btn.btn-sm.btn-outline.font-light[disabled="disabled"]
+                = link_to affirmation_path(wish) do
+                  button.btn.btn-sm.btn-outline.font-light
                     | アファメーションをはじめる
             /.collapse
               input[type="checkbox"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
   resources :wishes, only: %i[index new create edit update destroy]
   resources :reflections, only: %i[edit update]
+  resources :affirmations, only: %i[show]
   resources :cheers, only: %i[index create]
   resources :oauths, only: %i[destroy]
   resources :line_notifications, only: %i[update]


### PR DESCRIPTION
### 内容
+ ユーザーが宣言した願いごとに対してアファメーションができる機能を追加しました。アファメーション画面に表示される内容はユーザーが「願い中」としている願いごとに限定されます(振り返り画面にて成就および不必要とした願いごとは表示されません)(d69d6b655e1ed0e718c3e664c03d4806199b60c6, 0db72773b1ccdeaa95991f530ecf61441dda9447, 129750a8dc58c000b03698536f16f7ec8307fbaa)。
+ 上記に伴い、願いごと一覧画面にある「アファメーションをはじめる」ボタンを有効にしました(5e1da383e0aeb32ec2060d2c19da51449345feb6)。

### 確認手順および確認結果
+ 願いごと一覧画面において「アファメーションをはじめる」ボタンを押下すると、アファメーション画面に遷移し、願いごとの内容がエフェクトを伴って表示されることを確認(下記の場合、諦めていた〜の願いごとは成就扱いとなっているため、アファメーション画面には表示されないことを確認)
+ エフェクト終了後にページ下部にボタンが表示されることを確認
<img width="200" src="https://user-images.githubusercontent.com/99260932/201838931-0ec5a7b4-1b28-46a6-911e-54f798287ff9.png">　<img width="200" src="https://user-images.githubusercontent.com/99260932/201838970-80a84ff3-4bab-4482-9d92-768b8410a893.png">　<img width="200" src="https://user-images.githubusercontent.com/99260932/201839072-d0b1f67b-1c6c-430d-8e66-0ff9cebbf862.png">


### Issue
close #40 