### PR TITLE
満月時のLINE通知に対する願いごと内容の追加・LINE通知時の表示画像設定

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+worker: bundle exec rake jobs:work

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -29,7 +29,7 @@ class OauthsController < ApplicationController
   def destroy
     @oauth = current_user.authentications.find(params[:id])
     @oauth.destroy!
-    current_user.update!(line_name: nil, picture_url: nil)
+    current_user.update!(line_name: nil, picture_url: nil, need_newmoon_msg: false, need_fullmoon_msg: false)
     redirect_to profile_path, notice: t('.destroyed')
   end
 

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -27,13 +27,12 @@ namespace :moon_notification do
     end
   end
 
-  # 画像は後で差し替え予定
   def flex_message(user, moon, moon_type)
     {
       "type": "bubble",
       "hero": {
         "type": "image",
-        "url": "https://scdn.line-apps.com/n/channel_devcenter/img/fx/01_1_cafe.png",
+        "url": "#{moon_type.include?('新月') ? 'https://res.cloudinary.com/dhbscendw/image/upload/v1669192782/line_notice_newmoon_xeecky.jpg' : 'https://res.cloudinary.com/dhbscendw/image/upload/v1669193825/line_notice_fullmoon_kwoutr.jpg'}",
         "size": "full",
         "aspectRatio": "16:9",
         "aspectMode": "cover",

--- a/lib/tasks/moon_notification.rake
+++ b/lib/tasks/moon_notification.rake
@@ -11,7 +11,7 @@ namespace :moon_notification do
       target_users = fullmoon.wished_users.preload(:authentications).where(need_fullmoon_msg: :true)
       send_line_notifications(target_users, fullmoon, '満月') if target_users.present?
     else
-      p '該当なし'
+      p "#{Time.current}: 該当なし"
     end
   end
 
@@ -21,9 +21,9 @@ namespace :moon_notification do
         type: 'flex',
         altText: "#{moon.zodiac_sign.name_i18n}#{moon_type}のお知らせ",
         contents: flex_message(user, moon, moon_type)
-       }
-      line_uid = user.authentications.find_by(provider: 'line').uid
-      LineNotificationJob.perform_later(line_uid, message)
+      }
+      line_uid = user.authentications.find_by(provider: 'line')&.uid
+      LineNotificationJob.perform_later(line_uid, message) if line_uid.present?
     end
   end
 
@@ -66,14 +66,54 @@ namespace :moon_notification do
                 "contents": [
                   {
                     "type": "text",
-                    "text": text_content(user, moon, moon_type),
+                    "text": greeting_message(user, moon, moon_type),
                     "wrap": true,
                     "color": "#666666",
                     "size": "sm",
                     "flex": 5,
-                    "align": "center"
+                    "align": "start"
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "type": "box",
+            "layout": "vertical",
+            "margin": "lg",
+            "spacing": "sm",
+            "contents": [
+              {
+                "type": "box",
+                "layout": "baseline",
+                "spacing": "sm",
+                "contents": [
+                  {
+                    "type": "text",
+                    "text": "#{moon_type.include?('新月') ? '【おすすめのテーマ】' : '【願いごと】'}",
+                    "wrap": true,
+                    "color": "#aaaaaa",
+                    "size": "sm",
+                    "flex": 1,
+                    "align": "center"
+                  },
+                ]
+              }
+            ]
+          },
+          {
+            "type": "box",
+            "layout": "baseline",
+            "margin": "lg",
+            "spacing": "sm",
+            "contents": [
+              {
+                "type": "text",
+                "text": declaration_message(user, moon, moon_type),
+                "wrap": true,
+                "size": "sm",
+                "color": "#666666",
+                "flex": 5
               }
             ]
           }
@@ -93,12 +133,6 @@ namespace :moon_notification do
               "label": "#{moon_type.include?('新月') ? '願いごとを宣言する' : '願いごとを振り返る'}",
               "uri": "#{moon_type.include?('新月') ? 'https://new-moon-wishes.herokuapp.com/wishes/new' : 'https://new-moon-wishes.herokuapp.com/wishes'}"
             }
-          },
-          {
-            "type": "box",
-            "layout": "vertical",
-            "contents": [],
-            "margin": "sm"
           }
         ],
         "flex": 0
@@ -106,11 +140,19 @@ namespace :moon_notification do
     }
   end
 
-  def text_content(user, moon, moon_type)
+  def greeting_message(user, moon, moon_type)
     if moon_type == '新月'
       content = "#{user.name}さん、おはようございます。今日は#{I18n.l(moon.newmoon_time, format: :only_time)}に#{moon.zodiac_sign.name_i18n}で#{moon_type}を#{moon.newmoon_time < Time.current ? '迎えました' : '迎えます'}。新月から48時間以内に願いごとを宣言してみませんか？"
     elsif moon_type == '満月'
       content = "#{user.name}さん、おはようございます。今日は#{I18n.l(moon.fullmoon_time, format: :only_time)}に#{moon.zodiac_sign.name_i18n}で#{moon_type}を#{moon.newmoon_time < Time.current ? '迎えました' : '迎えます'}。半年前に宣言した願いごとが達成されているか、振り返りをしてみませんか？"
+    end
+  end
+
+  def declaration_message(user, moon, moon_type) 
+    if moon_type == '新月'
+      content = "#{moon.zodiac_sign.traits.map(&:keyword).join('・')}"
+    elsif moon_type == '満月'
+      content = user.wishes.find_by(moon_id: moon.id)&.declarations.map.with_index(1){ |declaration, i| "#{i}.#{declaration.message}" }.join("\n")
     end
   end
 end


### PR DESCRIPTION
### 内容
+ 満月時のLINE通知のメッセージにユーザーが宣言した願いごとの内容を表示するよう修正しました(495fa79e1fee8dd86774dbab6ddcbdfe0ba52ed5)。
+ LINE通知送信処理時、各ユーザーに紐づくLINEのuid(Userモデルに紐づくAuthenticationモデルのuidカラム)が存在しているかどうか確認するよう修正しました(495fa79e1fee8dd86774dbab6ddcbdfe0ba52ed5)。
+ 新月および満月時のLINE通知メッセージに表示される画像を変更しました(fceeebc049d096586240c6d70c4bff25c8d33749)。
+ `Procfile`を追加しました(8a423cd335070b3ce1cac35b33c60981dad7716c)。

#### Fix
+ LINEアカウントの連携解除時、新月および満月の通知設定がOFFとなるよう処理を修正しました(6e5d817bad7e43c43abf3c020b8deae444fe4cab)。

### 確認手順および確認結果
#### 事前準備
ngrokを使用し、`localhost:3000`を一時的に外部からアクセスできるようにし、アプリ側およびLINE Developersの設定ページにてコールバックURLも一時的にngrokによって発行されたURLに変更する

+ rakeタスクの新月および満月の抽出について、最新の月を一時的に設定し、rakeタスクを実行した場合、下記画像のように新月・満月のそれぞれにおいて設定した異なる画像が表示され、かつ満月時の通知メッセージには、ユーザーが該当の新月において宣言した願いごとの内容が表示されることを確認
<img width="198" src="https://user-images.githubusercontent.com/99260932/203575654-62f7cd81-cd4d-4174-9ec7-9d5db8fe5d48.jpg">　<img width="198" src="https://user-images.githubusercontent.com/99260932/203575676-b236425a-ebf3-4533-ab13-3eab8b2ee47e.jpg">

+ LINEアカウントを連携解除処理をした場合、新月および満月時のLINE通知設定がOFF(`false`)に変更されることを確認
<img width="700" alt="スクリーンショット 2022-11-23 23 34 14" src="https://user-images.githubusercontent.com/99260932/203576553-5d387332-76cb-40e4-a5b9-301ef6a1dff2.png">

### Issue
close #67 
close #101 