### PR TITLE
願いごと宣言のバリデーション失敗時の処理修正および文字数カウント機能の追加

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -1,2 +1,0 @@
-class DeclarationsController < ApplicationController
-end

--- a/app/models/form/declaration_collection.rb
+++ b/app/models/form/declaration_collection.rb
@@ -34,6 +34,7 @@ class Form::DeclarationCollection
   end
 
   def save
+    self.declarations = declarations.partition{ |dec| dec[:message].present? }.then{ |messages, nils| messages + nils }
     return false unless wish_is_not_created? && valid?
     ActiveRecord::Base.transaction do
       @wish.save!

--- a/app/views/shared/_one_declaration_form.html.slim
+++ b/app/views/shared/_one_declaration_form.html.slim
@@ -4,7 +4,7 @@
 		= render 'shared/error_messages', object: f.object
 		.flex.justify-between.items-center
 			.form-control
-				label.swap.swap-flip.text-xl.pl-1.pr-2.py-2.mt-3
+				label.swap.swap-flip.text-xl.pl-1.pr-2.py-2
 					= f.check_box :is_shared, { checked: f.object.is_shared }, 'true', 'false'
 					.swap-on
 						.tooltip[data-tip="公開"]
@@ -13,7 +13,9 @@
 						.tooltip[data-tip="非公開"]
 							i.fas.fa-lock.text-indigo-400
 			.form-control.text-indigo-800.mt-3.w-full
-				= f.text_area :message, placeholder: '願いごと', class: "textarea leading-tight border-opacity-10 bg-indigo-50 focus:outline-none"
+				= f.text_area :message, placeholder: '願いごと', class: "textarea leading-tight border-opacity-10 bg-indigo-50 focus:outline-none", id: "js-message-form-#{f.index}", onkeyup: "showLength(value, 'js-input-length-#{f.index}', 'js-message-form-#{f.index}');"
+				p class="text-xs text-right text-gray-400" id="js-input-length-#{f.index}"
+					| 0/100文字
 		.flex.justify-start.mt-2
 			.flex.items-center
 				p.mr-3.xl:mr-4.text-sm.text-indigo-400 TAG
@@ -23,3 +25,15 @@
 						=> b.label do
 							= b.check_box(class: "peer hidden")
 							= b.label(class: "badge badge-outline opacity-50 peer-checked:border-indigo-800 peer-checked:text-indigo-800 peer-checked:opacity-100 peer-checked:bg-gradient-to-r from-purple-100 via-indigo-100 to-blue-100")
+		
+javascript:
+	function showLength(str, displayId, inputFormId) {
+  	document.getElementById(displayId).innerHTML = str.length + "/100文字";
+		if (str.length > 100) {
+			document.getElementById(inputFormId).classList.add("text-red-400");
+  		document.getElementById(displayId).classList.add("text-red-400");
+		} else {
+			document.getElementById(inputFormId).classList.remove("text-red-400");
+  		document.getElementById(displayId).classList.remove("text-red-400");
+		}
+	}

--- a/app/views/shared/_one_declaration_form.html.slim
+++ b/app/views/shared/_one_declaration_form.html.slim
@@ -37,3 +37,14 @@ javascript:
   		document.getElementById(displayId).classList.remove("text-red-400");
 		}
 	}
+	window.addEventListener("load", function() {
+		for (let i = 0; i < 10; i++) {
+			let input_form = document.getElementById(`js-message-form-${i}`);
+			let count_display = document.getElementById(`js-input-length-${i}`);
+			count_display.innerHTML = input_form.textContent.length + "/100文字";
+			if (input_form.textContent.length > 100) {
+				document.getElementById(`js-input-length-${i}`).classList.add("text-red-400");
+				document.getElementById(`js-message-form-${i}`).classList.add("text-red-400");
+			}
+		}
+	});


### PR DESCRIPTION
### 内容
+ 願いごと宣言および編集画面において、願いごとの文字数カウントを表示するようにしました。100 
文字を超えると願いごと本文およびカウント表示が赤字となるよう機能を追加しました(35c9a48678f13516aaa6f9ed42706d40249e0bcf, 68d4e1339e3355111b2b7c26d407e4a4e8f4e9b3)。

#### Fix
+ 願いごとの保存処理においてバリデーションが失敗すると、入力されている項目の間に空欄があった場合に正しく入力欄が表示されなくなるため(「願いごとを追加する」ボタン押下で表示されるため)、コントローラー側で願いごとの並び替えを行うことにより正しく表示されるよう修正しました(be8fa7a366949904029e3843a984f62b68267ac1)。
+ 使用していない`declarations_controller.rb`を削除しました(5c94c7ad01ce5e1fae4ed4cd38c6595059f9d051)。

### 確認手順および確認結果
+ `localhost:3000/wishes/new`にて、願いごとを入力すると文字数が動的にカウントされ、100文字を超えると赤文字に変化することを確認
　<img width="198" src="https://user-images.githubusercontent.com/99260932/205589986-14b9858a-5fee-409b-9984-4580b4bdfdec.png">
+ 上記の保存処理失敗後、空欄が詰められてレンダリングされていることを確認
　<img width="198" src="https://user-images.githubusercontent.com/99260932/205590292-3ddbd1e2-801e-4b56-b614-340abad49c33.png">