### PR TITLE
デザイン(表示幅および配色等)およびバグの修正

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -1,1 +1,2 @@
-@import '@moesaid/cleopatra/dist/css/style';
+/* Cleopatra template */
+@import "@moesaid/cleopatra/dist/css/style.css";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,8 +39,13 @@ module ApplicationHelper
     end
   end
 
-  def next_newmoon
-    Moon.latest
+  def next_newmoon_message
+    moon_latest = Moon.latest
+    if moon_latest.newmoon_time < Time.current
+      message = "現在、新月を迎えてから48時間以内です。新月の願いごとをしてみませんか？"
+    else
+      message = "次の新月は、#{l(moon_latest.newmoon_time)}に#{moon_latest.zodiac_sign.name_i18n}で起こります。"
+    end
   end
 
   def get_moon_age

--- a/app/views/cheers/index.html.slim
+++ b/app/views/cheers/index.html.slim
@@ -9,18 +9,18 @@
         | 叶えたい願い
       button.btn.btn-sm.btn-outline.text-indigo-900.hover:bg-indigo-800[onclick="toggleNavbar('fulfilled', 'wished')"]
         | 叶った願い
-  div id="wished" class="flex flex-col"
+  div id="wished" class="flex flex-col items-center"
     .grid.place-items-center.mb-5
 	    p.text-sm.text-indigo-400 他の人の願いを応援しよう
-    .grid.px-2.mb-10.mx-auto.md:w-4/5.lg:w-3/5
+    .grid.w-full.px-5.mb-10.md:w-4/5.lg:w-3/5
       = render partial: 'other_declaration', collection: @other_wished_declarations
       - if @other_wished_declarations.blank?
         .text-indigo-900.my-10
           | まだ願いがないようです#{"&#128532;".html_safe}
-  div id="fulfilled" class="hidden flex-col"
+  div id="fulfilled" class="hidden flex-col items-center"
     .grid.place-items-center.mb-5
 	    p.text-sm.text-indigo-400 他の人はこんな願いを叶えました
-    .grid.px-2.mb-10.mx-auto.md:w-4/5.lg:w-3/5
+    .grid.w-full.px-5.mb-10.md:w-4/5.lg:w-3/5
       = render partial: 'other_declaration', collection: @other_fulfilled_declarations
       - if @other_fulfilled_declarations.blank?
         .text-indigo-900.my-10

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -4,7 +4,7 @@
     h1.mt-6.mb-3.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
       = t('.title')
     - if @current_user.name&.include?('GUEST') && @current_user.email&.include?('guest_') && @current_user.authentications.blank?
-      .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
+      .card.shadow-lg.shadow-indigo-900/10.w-4/5.sm:w-3/5.lg:w-2/5
         .card-body.p-5
           span.badge
             = User.human_attribute_name(:name)
@@ -19,10 +19,10 @@
               .btn.btn-sm.btn-outline.btn-error.font-light
                 | ゲストユーザー削除
             = link_to edit_user_path(current_user) do
-              button.btn.btn-sm.btn-outline.font-light
+              button.btn.btn-sm.btn-outline.btn-primary.font-light
                 | このまま新規登録する
     - else
-      .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
+      .card.shadow-lg.shadow-indigo-900/10.w-4/5.sm:w-3/5.lg:w-2/5
         .card-body.p-5
           span.badge
             = User.human_attribute_name(:name)
@@ -31,16 +31,13 @@
           span.badge
             = User.human_attribute_name(:email)
           p.ml-3
-            - if @current_user.email&.exclude?('guest_') && @current_user.email&.exclude?('@example.com')
-              = @current_user.email
-            - else
-              | 未登録
+            = @current_user.email.nil? ? '未登録' : @current_user.email
           .card-actions.justify-end.mt-3
             label.modal-button.text-indigo-400.text-md[for="my-modal-7"]
               .btn.btn-sm.btn-outline.btn-error.font-light
                 | ユーザー削除
             = link_to edit_profile_path do
-              button.btn.btn-sm.btn-outline.font-light
+              button.btn.btn-sm.btn-outline.btn-primary.font-light
                 | 編集
     
     h1.mt-6.mb-3.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
@@ -53,12 +50,12 @@
             .flex-col.pl-2.pr-5.flex-grow
               = @current_user.line_name
               p.text-sm.text-gray-400 連携されています
-            - if @current_user.crypted_password.present? && @current_user.email.present? && @current_user.email.exclude?('guest_') && @current_user.email.exclude?('@example.com')
+            - if @current_user.crypted_password.present? && @current_user.email.present? && @current_user.email&.exclude?('guest_') && @current_user.email&.exclude?('@example.com')
               = button_to oauth_path(@oauth.id), method: :delete do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 解除
             - else
-              button.btn.btn-sm.btn-outline.font-light[disabled="disabled"]
+              button.btn.btn-sm.btn-outline.btn-primary.font-light[disabled="disabled"]
                 | 解除 
           .divider.mt-3.mb-1.text-sm
             | 現在の通知設定
@@ -67,26 +64,26 @@
               = "&#127761;".html_safe
               p 新月の日に通知する
               = button_to line_notification_path(@current_user, need_newmoon_msg: :false), method: :patch do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 解除
             - else
               = "&#127761;".html_safe
               p 新月の日に通知しない
               = button_to line_notification_path(@current_user, need_newmoon_msg: :true), method: :patch do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 通知
           .flex.items-center
             - if @current_user.need_fullmoon_msg?
               = "&#127765;".html_safe
               p 満月の日に通知する
               = button_to line_notification_path(@current_user, need_fullmoon_msg: :false), method: :patch do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 解除
             - else
               = "&#127765;".html_safe
               p 満月の日に通知しない
               = button_to line_notification_path(@current_user, need_fullmoon_msg: :true), method: :patch do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 通知
       label.modal-button.text-indigo-400.text-md.mt-5[for="my-modal-5"]
         i.fas.fa-question-circle.pr-1
@@ -171,7 +168,7 @@ label.modal.cursor-pointer[for="my-modal-6"]
         button.btn.btn-sm.btn-outline.btn-error.font-light
           | 削除してログアウト
       = link_to edit_user_path(@current_user) do
-        button.btn.btn-sm.btn-outline.font-light
+        button.btn.btn-sm.btn-outline.btn-primary.font-light
           | このまま新規登録する
 
 input#my-modal-7.modal-toggle[type="checkbox"]
@@ -185,5 +182,5 @@ label.modal.cursor-pointer[for="my-modal-7"]
       = button_to user_path(@current_user), method: :delete do
         button.btn.btn-sm.btn-outline.btn-error.font-light
           | ユーザー削除
-      label.btn.btn-sm.btn-outline.font-light[for="my-modal-7"]
+      label.btn.btn-sm.btn-outline.btn-primary.font-light[for="my-modal-7"]
         | キャンセル

--- a/app/views/static_pages/menu.html.slim
+++ b/app/views/static_pages/menu.html.slim
@@ -9,7 +9,7 @@
         .card.shadow-lg.w-4/5.sm:w-3/5.lg:w-2/5
           = image_tag "moon_phase/moon_#{moon_phase_image}.png"
           .card-body.p-5.text-center
-            p.text-sm 本日の月齢は#{get_moon_age}です。次の新月は、#{l(next_newmoon.newmoon_time)}に#{next_newmoon.zodiac_sign.name_i18n}で起こります。
+            p.text-sm 本日の月齢は#{get_moon_age}です。#{next_newmoon_message}
     .grid.place-items-center
       h1.place-items-center.my-6.text-xl.text-bold.bg-indigo-100.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
         | MENU

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -1,11 +1,11 @@
-.hero.max-h-full.lg:max-h-screen
+.hero.max-h-full
 	= image_tag 'top_eyecatch_moon.jpg'
 	.hero-overlay.bg-opacity-10.sm:bg-opacity-30
 	.hero-content.text-center.text-neutral-content
 		.max-w-lg.lg:max-w-xl
-			h1.mb-5.text-xl.md:text-2xl.lg:text-3xl.font-bold
+			h1.md:mb-5.text-xl.md:text-2xl.lg:text-3xl.font-bold
 				| 心の中にあるその願い、<br>ここで"言葉"にしてみませんか
-			p.mb-5.text-indigo-100.md:text-lg.hidden.sm:flex
+			p.mt-3.mb-5.text-indigo-100.md:text-lg.hidden.sm:flex
 				| 新月に合わせて、自分のやりたいこと・叶えたいこと・もうやめたいことなどを「願いごと」として宣言。半年後、あなたのLINEへ振り返りの時期であることをお知らせします。
 			= button_to guest_login_path do
 				button.btn.border-none.hidden.sm:inline-block.bg-gradient-to-r.from-purple-700.via-indigo-600.to-blue-700.hover:bg-gradient-to-r.hover:from-purple-600.hover:via-indigo-500.hover:to-blue-600
@@ -24,7 +24,7 @@ section.bg-indigo-50
 		.text-xl.font-semibold.text-center.text-indigo-900.lg:text-2xl
 			| このアプリでできること 
 	.grid.grid-cols-1.gap-2.mt-4.xl:mt-6.xl:gap-3.md:grid-cols-2.sm:mx-14
-		.flex.flex-col.items-center.mx-5.mb-5.p-6.space-y-3.text-center.bg-white.rounded-xl.shadow-lg.bg-base-100
+		.flex.flex-col.items-center.mx-5.mb-5.p-6.space-y-3.text-center.bg-white.rounded-xl.shadow-md.shadow-indigo-900/10.bg-base-100
 			span.inline-block.p-3.text-indigo-700.rounded-full.bg-gradient-to-r.from-purple-200.via-indigo-100.to-blue-200
 				i.fas.fa-feather-alt.text-2xl.w-8.pt-1
 			h1.text-xl.capitalize.text-transparent.bg-clip-text.bg-gradient-to-r.from-purple-700.via-indigo-600.to-blue-700
@@ -84,5 +84,5 @@ section.bg-indigo-50
 		.text-md.text-center.text-indigo-400
 			| 新規登録をスキップして、すぐに始めていただけます。
 		= button_to guest_login_path do
-			button.btn.mt-6.border-none.bg-gradient-to-r.from-purple-700.via-indigo-600.to-blue-700.hover:bg-gradient-to-r.hover:from-purple-600.hover:via-indigo-500.hover:to-blue-600
+			button.btn.btn-wide.w-full.mt-6.border-none.bg-gradient-to-r.from-purple-700.via-indigo-600.to-blue-700.hover:bg-gradient-to-r.hover:from-purple-600.hover:via-indigo-500.hover:to-blue-600
 				| 今から言葉にしてみる

--- a/app/views/wishes/index.html.slim
+++ b/app/views/wishes/index.html.slim
@@ -8,7 +8,7 @@
   .grid.place-items-center.mb-10
     - if @wishes.present?
       - @wishes.each do |wish|
-        .card.shadow-lg.mt-5.w-4/5.lg:w-3/5.xl:max-w-2xl
+        .card.shadow-md.shadow-indigo-900/10.mt-5.w-4/5.lg:w-3/5.xl:max-w-2xl
           .p-1.bg-gradient-to-r.from-purple-600.via-indigo-500.to-blue-600
             p.text-indigo-50.text-center
               | #{wish.zodiac_sign.name_i18n}新月
@@ -17,7 +17,7 @@
           .p-2.text-indigo-700
             - wish.declarations.each do |dec|
               div class="flex rounded #{highlight(dec.come_true)}"
-                p.mx-1 #{fullmoon_emoji_if(dec)}
+                p.mx-1.mt-1.text-sm #{fullmoon_emoji_if(dec)}
                 .flex-row
                   p.mt-1.leading-tight
                     | #{dec.message}
@@ -43,35 +43,16 @@
                 button.btn.btn-sm.btn-outline.btn-error.font-light
                   | 削除
               = link_to edit_wish_path(wish) do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 編集
               = link_to edit_reflection_path(wish) do
-                button.btn.btn-sm.btn-outline.font-light
+                button.btn.btn-sm.btn-outline.btn-primary.font-light
                   | 振り返る
               .flex-row
                 = link_to affirmation_path(wish) do
-                  button.btn.btn-sm.btn-outline.font-light
+                  button.btn.btn-sm.btn-outline.btn-primary.font-light
                     | アファメーションをはじめる
-            /.collapse
-              input[type="checkbox"]
-              .collapse-title.text-sm.font-medium.text-center
-                | EDIT MENU
-              .collapse-content
-                .card-actions.justify-center.mt-3
-                  = button_to  wish_path(wish), method: :delete do
-                    button.btn.btn-sm.btn-outline.btn-error.font-light
-                      | 削除
-                  = link_to edit_wish_path(wish) do
-                    button.btn.btn-sm.btn-outline.font-light
-                      | 編集
-                  = link_to edit_reflection_path(wish) do
-                    button.btn.btn-sm.btn-outline.font-light
-                      | 振り返る
-                  .flex-row
-                    = link_to edit_wish_path(wish) do
-                      button.btn.btn-sm.btn-outline.font-light
-                        | アファメーションをはじめる
-                
+
     - else
       .grid.place-items-center.mb-10
         p.mt-10.text-indigo-900.text-center


### PR DESCRIPTION
### 内容
#### Fix
+ 各画面のデザインを修正しました。
　1. 願いごと一覧画面のボタンの配色および絵文字位置のズレを修正(cace1ded31c0a7b99a1507019e8f9a4e8f6cf59e)
　2. ログイン前TOP画面の「このアプリでできること」文字の位置と影の色を修正(804b8e7e0c2994426b2adbf00ec098c69b58d191)
　3. 願いごと応援画面での各願いごとの横幅サイズが文字数によらず幅いっぱいに広がるよう修正(c521d34f9cdee1cecf88a5ed9f81c619ee31ef5c)
　4. プロフィール画面のボタンの配色および影の色を修正(52ff3e5560c240189d4e4f9b95f530876134aa60)
+ プロフィール画面のメールアドレス表示についてゲストユーザーでない場合でも「未登録」と表示される状態を修正しました(52ff3e5560c240189d4e4f9b95f530876134aa60)。
+ 新月から48時間以内にログイン後TOP画面にアクセスした際、「次の新月は〜」で始まる説明部分に直近の経過済み新月の日時が表示されてしまっているため、新月から48時間以内の場合は「現在、新月を迎えてから48時間以内です。新月の願いごとをしてみませんか？」と表示するよう修正しました(3141626acad8b5f5e7b919ee33205bd76da3c9de)。
+ 管理画面用の`admin.css`が本番環境にて反映されないため、コメントを追加してファイル内容を変更しました(1cbafe88a73adabe793274fbc5ab29336f0daa69)。(開発環境にて`bin/rails assets:precompile RAILS_ENV=production`コマンド実行で正しくアセットファイルが生成されていることは確認済み)

### Issue
close #120 