### PR TITLE
願いごと一覧画面にて応援人数の表示を追加

### DIFF
--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -1,6 +1,6 @@
 class WishesController < ApplicationController
   def index
-    @wishes = current_user.wishes.order(id: :desc).preload(declarations: :tags).preload(:zodiac_sign)
+    @wishes = current_user.wishes.order(id: :desc).preload([{declarations: :tags}, {declarations: :cheers}, :zodiac_sign])
   end
 
   def new

--- a/app/views/wishes/index.html.slim
+++ b/app/views/wishes/index.html.slim
@@ -28,6 +28,9 @@
                   - dec.tags.each do |tag|
                     .badge.badge-xs.mt-1.mr-1.bg-indigo-100.text-indigo-400.border-opacity-20
                       => tag.name
+                  - if dec.cheers.present?
+                    .badge.badge-ghost.badge-xs.mt-1.mr-1.bg-indigo-400.text-white.border-none
+                      => "#{dec.cheers.count}人が応援"
               .divider.m-0
             .p-2.mt-2.mb-4.bg-indigo-50.rounded
               - if wish.memo.present?

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "tailwindcss": "^3.1.8"
   },
   "scripts": {
-    "build:css:application": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify",
-    "build:css:admin": "tailwindcss -i ./app/assets/stylesheets/admin.css -o ./app/assets/builds/admin.css --minify",
-    "build:css": "yarn run build:css:application && yarn run build:css:admin",
+    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
   }
 }


### PR DESCRIPTION
### 内容
+ 願いごと一覧画面にてその願いごとを応援した他ユーザーの合計人数を表示しました(444307b22ab5b5a1d09e783df7df0066958150f9)。

#### Fix
+ 管理画面用の`admin.css`が反映されない件について、前回のPull Requestにて修正した`package.json`内のコマンドが実行はされるものの、デプロイ先のHeroku上で`ActionView::Template::Error (The asset "application.css" is not present in the asset pipeline.)`エラーとなってしまうため、元のコマンドへ戻しました(98750c5c5c70d278ee05b8c77fb18ab8012d207d)。

### 確認手順および確認結果
+ `localhost:3000/wishes`にて応援人数が1人以上の場合はその人数がタグ表示部分の最後に「○人が応援」という形で表示され、0人の場合は表示されないことを確認
　<img src="https://user-images.githubusercontent.com/99260932/211184902-f511de68-3ca1-47ae-92a6-629195339be0.png" width="250">

### Issue
close #124 